### PR TITLE
Changed the url setting and added css to desing embeded codes

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -6,6 +6,7 @@
 @use "./widgets/math-jax";
 @use "./widgets/sidebar";
 @use "./widgets/algolia";
+@use "./widgets/code";
 
 body {
   font-family: "Raleway", "Roboto", "Hiragino Kaku Gothic ProN", "BIZ UDPGothic", sans-serif !important;

--- a/assets/css/widgets/code.scss
+++ b/assets/css/widgets/code.scss
@@ -1,0 +1,27 @@
+article.card-wrapper pre {
+  line-height: 1.15rem;
+  border-radius: 10px;
+
+  /* for block of numbers */
+  .hljs-ln-numbers {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    text-align: center;
+    vertical-align: top;
+    padding-right: 15px;
+  }
+
+  tr {
+    border-bottom: none;
+  }
+}
+
+article.card-wrapper p code {
+  margin: 0 0.25rem;
+  padding: 0.375rem;
+  white-space: nowrap;
+}

--- a/exampleSite/content/posts/tech/hello-world.md
+++ b/exampleSite/content/posts/tech/hello-world.md
@@ -70,9 +70,22 @@ Markdownは、簡単に構造化された文書を作成するための軽量マ
 
 コードブロックは ``` で囲みます：
 
-```python
+- example
+
+{{< highlight markdown >}}
+```python {linenos=inline}
 def hello_world():
     print("Hello, World!")
+    print(sorted([*[num for num in [34, 12, 57, 23, 89, 45, 67, 1, 90, 33]], max([num for num in [34, 12, 57, 23, 89, 45, 67, 1, 90, 33]]) * 2]))
+```
+{{</ highlight >}}
+
+- result
+
+```python {linenos=inline}
+def hello_world():
+    print("Hello, World!")
+    print(sorted([*[num for num in [34, 12, 57, 23, 89, 45, 67, 1, 90, 33]], max([num for num in [34, 12, 57, 23, 89, 45, 67, 1, 90, 33]]) * 2]))
 ```
 
 あるいはショートコード{{</* highlight */>}}を使ってください

--- a/layouts/_default/article-card-sm.html
+++ b/layouts/_default/article-card-sm.html
@@ -1,5 +1,5 @@
 <div class="card border-0">
-  <a href="{{ .Permalink }}" class="row">
+  <a href="{{ .RelPermalink }}" class="row">
     <div class="row">
       <div class="col-3">
         {{ if .Page.Params.thumbnail }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,7 +17,7 @@
 
   {{ range $page := $paginator.Pages }}
     <article class="li article-hover">
-      <a class="text-decoration-none" href="{{ .Permalink | safeURL }}">
+      <a class="text-decoration-none" href="{{ .RelPermalink }}">
         <div class="card mb-3 border-0 bg-body">
           <div class="row g-0">
             <div

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,7 +17,7 @@
 
   {{ range $page := $paginator.Pages }}
     <article class="li article-hover">
-      <a class="text-decoration-none" href="{{ .Permalink }}">
+      <a class="text-decoration-none" href="{{ .Permalink | safeURL }}">
         <div class="card mb-3 border-0 bg-body">
           <div class="row g-0">
             <div

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -35,10 +35,7 @@
             {{ range .Params.categories }}
               <div class="col ps-0 me-2">
                 <i class="mx-0 fas fa-bookmark" aria-hidden="true"></i
-                ><a
-                  href="{{ $.Site.BaseURL }}/categories/{{ . | urlize }}"
-                  class="fw-medium"
-                >
+                ><a href="/categories/{{ . | urlize }}" class="fw-medium">
                   {{ . }}</a
                 >
               </div>
@@ -57,10 +54,7 @@
                   class="mx-0 fas fa-tags {{ $colorClass }}"
                   aria-hidden="true"
                 ></i>
-                <a
-                  href="{{ $.Site.BaseURL }}/tags/{{ . | urlize }}"
-                  class="fw-medium"
-                >
+                <a href="/tags/{{ . | urlize }}" class="fw-medium">
                   {{ . }}
                 </a>
               </div>

--- a/layouts/partials/categories.html
+++ b/layouts/partials/categories.html
@@ -7,7 +7,7 @@
           <span class="col-6 g-0">
             <a
               class="btn bg-body link-opacity-75-hover"
-              href="{{ $.Site.BaseURL }}/categories/{{ .Name | urlize }}"
+              href="/categories/{{ .Name | urlize }}"
             >
               <small class="text-capitalize fw-semibold text-body">
                 <i class="fas fa-bookmark" aria-hidden="true"></i>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,11 +8,14 @@
       {{ end }}
       {{ now.Year }}
       {{ with .Site.Params.Copyright }}{{ . | safeHTML }}{{ end }} | Powered by
-      <a href="https://gohugo.io/">HUGO</a> |
-      <a href="{{ .Site.BaseURL }}privacy/">プライバシーポリシーと免責事項</a>
+      <a href="https://gohugo.io/" target="_blank">HUGO</a> |
+      <a href="/privacy/">プライバシーポリシーと免責事項</a>
       {{ $url := .Site.Params.contactUrl }}
       {{ if $url }}
-        | <a href="{{ $url | safeURL }}">お問い合わせ</a>
+        |
+        <a href="{{ $url | safeURL }}" target="_blank" rel="noreferrer"
+          >お問い合わせ</a
+        >
       {{ end }}
     </p>
   </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,7 +12,7 @@
       <a href="{{ .Site.BaseURL }}privacy/">プライバシーポリシーと免責事項</a>
       {{ $url := .Site.Params.contactUrl }}
       {{ if $url }}
-        | <a href="{{ $url }}">お問い合わせ</a>
+        | <a href="{{ $url | safeURL }}">お問い合わせ</a>
       {{ end }}
     </p>
   </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,20 +8,21 @@
 
 <!-- load custom and main css files -->
 {{ $options := (dict "outputStyle" "compressed" "transpiler" "dartsass") }}
-{{ $mainstyle := resources.Get "css/styles.scss" | resources.ToCSS $options }}
+{{ $mainstyle := resources.Get "css/styles.scss" | resources.ToCSS $options | fingerprint }}
 {{ $styles := $mainstyle }}
 
 {{ if resources.Get "css/custom.scss" }}
   {{ $customstyle := resources.Get "css/custom.scss" | resources.ToCSS $options }}
-  {{ $styles = slice $mainstyle $customstyle | resources.Concat "css/bundle.css" }}
+  {{ $styles = slice $mainstyle $customstyle | resources.Concat "css/bundle.css" | fingerprint }}
 {{ end }}
 
 
 <link
   crossorigin="anonymous"
-  href="{{ $styles.Permalink  | safeURL }}"
+  href="{{ $styles.RelPermalink }}"
   rel="preload stylesheet"
   as="style"
+  integrity="{{ .Data.Integrity }}"
 />
 
 <!-- load Google Fonts -->
@@ -164,4 +165,37 @@
       integrity="{{ .Data.Integrity }}"
     ></script>
   {{ end }}
+{{ end }}
+
+{{/* syntax highlisht */}}
+<!-- コードのハイライト -->
+{{ if .Site.Params.EnableHighlight | default true }}
+  <link
+    rel="preload stylesheet"
+    as="style"
+    href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/base16/espresso.min.css"
+    integrity="sha512-Alf9gBIx7O9Pn9+n7HJXcwZK6uXCaGDNj5ScAAtNsQ5OpUHBaXLEAaX00Z9N8S9o9lTG7FKgnRB5eXwUQKNu6g=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
+  <script
+    defer
+    src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"
+    integrity="sha512-6yoqbrcLAHDWAdQmiRlHG4+m0g/CT/V9AGyxabG8j7Jk8j3r3K6due7oqpiRMZqcYe9WM2gPcaNNxnl2ux+3tA=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  ></script>
+  <script
+    defer
+    src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.8.0/highlightjs-line-numbers.min.js"
+    integrity="sha512-axd5V66bnXpNVQzm1c7u1M614TVRXXtouyWCE+eMYl8ALK8ePJEs96Xtx7VVrPBc0UraCn63U1+ARFI3ofW+aA=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  ></script>
+  <script>
+    window.addEventListener("load", function () {
+      hljs.highlightAll();
+      hljs.initLineNumbersOnLoad(); //行番号用の起動コードを追加
+    });
+  </script>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,7 +19,7 @@
 
 <link
   crossorigin="anonymous"
-  href="{{ $styles.Permalink }}"
+  href="{{ $styles.Permalink  | safeURL }}"
   rel="preload stylesheet"
   as="style"
 />

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,10 +1,7 @@
 <div class="container-xl">
   <nav class="navbar me-auto navbar-expand-lg">
     <div class="container-fluid">
-      <a
-        class="navbar-brand d-flex align-items-center"
-        href="{{ .Site.BaseURL }}"
-      >
+      <a class="navbar-brand d-flex align-items-center" href="/">
         {{ with .Site.Params.logoImageUrl }}
           <img
             src="{{ . | absURL }}"
@@ -17,7 +14,7 @@
           />
         {{ end }}
         <p
-          class="d-inline fs-2 logo-font m-0 ms-1"
+          class="d-inline fs-2 m-0 ms-1 fw-bolder"
           style="font-family: {{ .Site.Params.logoFontFamily }};"
         >
           {{ .Site.Title }}

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -1,6 +1,6 @@
 <!-- Icon trigger modal -->
 <a
-  href="{{ .Site.BaseURL }}search"
+  href="#"
   class="nav-link"
   data-bs-toggle="modal"
   data-bs-target="#searchModal"


### PR DESCRIPTION
## what changed
- `.Site.BaseURL` is removed because it returns a value like `https://~` instead of the current URL `http://~`
- Instead of the above, I added `RelPermalink` to return the relative url

## added
- css to design code embeded in the article
- `highlight.js` not to use `HUGO`'s default highlight functions