### PR TITLE
chore(release): bump version to 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "HikaeMe",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@algolia/client-search": "^5.49.2",
         "algoliasearch": "^5.49.2",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "test:e2e": "playwright test",
     "update": "ncu -u && npm install"
   },
-  "version": "1.2.2"
+  "version": "1.2.3"
 }


### PR DESCRIPTION
## Summary

Bump `package.json` version from 1.2.2 to 1.2.3 in preparation for the v1.2.3 release.

## Changes

- `package.json`: version 1.2.2 → 1.2.3

## Notes

- Version bumped using `npm version patch --no-git-tag-version`
- Git tag will be created on `main` after merge via GitHub Releases