### PR TITLE
fix(ci): skip tests for docs-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,44 @@ on:
     branches: ["**"]
 
 jobs:
+  changes:
+    name: Detect Changed File Types
+    runs-on: ubuntu-latest
+    outputs:
+      e2e_required: ${{ steps.decide.outputs.e2e_required }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect docs-only changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'README.md'
+              - 'docs/**'
+              - '.github/**/*.md'
+            non_docs:
+              - '**'
+              - '!README.md'
+              - '!docs/**'
+              - '!.github/**/*.md'
+
+      - name: Decide whether E2E is required
+        id: decide
+        run: |
+          if [[ "${{ steps.filter.outputs.docs }}" == "true" && "${{ steps.filter.outputs.non_docs }}" != "true" ]]; then
+            echo "e2e_required=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "e2e_required=true" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Test & Build
     runs-on: ubuntu-latest
+    needs: changes
     env:
       HUGO_VERSION: 0.157.0
       DART_SASS_VERSION: 1.97.3
@@ -29,6 +64,7 @@ jobs:
         run: npm ci
 
       - name: Run all tests
+        if: ${{ needs.changes.outputs.e2e_required == 'true' }}
         run: npm test
 
       - name: Create directory for user-specific executable files
@@ -56,7 +92,8 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: test
+    needs: [changes, test]
+    if: ${{ needs.changes.outputs.e2e_required == 'true' }}
     env:
       HUSKY: 0
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,2 @@
-# Run all tests before pushing
+# Run unit tests locally before pushing. E2E tests run in CI only.
 npm test
-npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A simple theme that displays only the bare minimum of elements readers need.
 ### Develop (for contributors/developers/AI)
 
 - Project Structure: [docs/develop/project-structure.md](./docs/develop/project-structure.md)
+- Testing Policy: [docs/develop/testing-policy.md](./docs/develop/testing-policy.md)
 
 ## Demo
 

--- a/docs/develop/testing-policy.md
+++ b/docs/develop/testing-policy.md
@@ -1,0 +1,32 @@
+# Testing Policy
+
+This document defines where each test type should run in this repository.
+
+## Policy
+
+- Unit tests run locally and in CI.
+- E2E tests (Playwright) run in CI only.
+
+## Local Development
+
+Run unit tests locally:
+
+```bash
+npm test
+```
+
+Do not run `npm run test:e2e` as part of local git hooks.
+
+## CI
+
+CI runs both categories for non-docs changes:
+
+- Unit tests in the `test` job
+- E2E tests in the `e2e` job
+
+For pull requests that only change documentation files (`README.md`, `docs/**`, `.github/**/*.md`), both CI test commands are skipped:
+
+- `npm test`
+- `npm run test:e2e`
+
+See [CI workflow](../../.github/workflows/ci.yml) for details.


### PR DESCRIPTION
## Overview

Adjust local and CI testing policy so documentation-only pull requests do not run `npm test` or `npm run test:e2e`, while keeping validation for non-documentation changes.

## Changes

- [x] Update `.husky/pre-push` to run unit tests locally and leave E2E to CI
- [x] Add `docs/develop/testing-policy.md` describing the local/CI testing policy
- [x] Update `.github/workflows/ci.yml` to skip `npm test` and `npm run test:e2e` for docs-only pull requests

## Related Issues

None.

## Screenshots

N/A (no UI changes).

## Testing

- [x] Conducted manual testing

## Checklist

- [x] I have followed the code style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation (if necessary)
- [x] I have added appropriate labels to this pull request

## Additional Comments

Docs-only pull requests still run the Hugo build. Test execution remains unchanged for non-documentation changes.
