### PR TITLE
chore(security): harden npm update flow with cooldown and min-release-age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     target-branch: "dev"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "version": "1.2.3",
       "dependencies": {
-        "@algolia/client-search": "^5.50.1",
-        "algoliasearch": "^5.50.1",
+        "@algolia/client-search": "^5.50.2",
+        "algoliasearch": "^5.50.2",
         "instantsearch.js": "^4.93.0"
       },
       "devDependencies": {
@@ -16,8 +16,8 @@
         "husky": "^9.1.7",
         "jsdom": "^29.0.2",
         "lint-staged": "^16.4.0",
-        "npm-check-updates": "^20.0.1",
-        "prettier": "^3.8.2",
+        "npm-check-updates": "^21.0.2",
+        "prettier": "^3.8.3",
         "prettier-plugin-go-template": "^0.0.15",
         "vitest": "^4.1.4"
       },
@@ -26,114 +26,114 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.1.tgz",
-      "integrity": "sha512-Xxk4l00pYI+jE0PNw8y0MvsQWh5278WRtZQav8/BMMi3HKi2xmeuqe11WJ3y8/6nuBHdv39w76OpJb09TMfAVQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.2.tgz",
+      "integrity": "sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.1.tgz",
-      "integrity": "sha512-4peZlPXMwTOey9q1rQKMdCnwZb/E95/1e+7KujXpLLSh0FawJzg//U2NM+r4AiJy4+naT2MTBhj0K30yshnVTA==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz",
+      "integrity": "sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.1.tgz",
-      "integrity": "sha512-i+aWHHG8NZvGFHtPeMZkxL2Loc6Fm7iaRo15lYSMx8gFL+at9vgdWxhka7mD1fqxkrxXsQstUBCIsSY8FvkEOw==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.2.tgz",
+      "integrity": "sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.1.tgz",
-      "integrity": "sha512-Hw52Fwapyk/7hMSV/fI4+s3H9MGZEUcRh4VphyXLAk2oLYdndVUkc6KBi0zwHSzwPAr+ZBwFPe2x6naUt9mZGw==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.2.tgz",
+      "integrity": "sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.1.tgz",
-      "integrity": "sha512-Bn/wtwhJ7p1OD/6pY+Zzn+zlu2N/SJnH46md/PAbvqIzmjVuwjNwD4y0vV5Ov8naeukXdd7UU9v550+v8+mtlg==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.2.tgz",
+      "integrity": "sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.1.tgz",
-      "integrity": "sha512-0V4Tu0RWR8YxkgI9EPVOZHGE4K5pEIhkLNN0CTkP/rnPsqaaSQpNMYW3/mGWdiKOWbX0iVmwLB9QESk3H0jS5g==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.2.tgz",
+      "integrity": "sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.1.tgz",
-      "integrity": "sha512-jofcWNYMXJDDr87Z2eivlWY6o71Zn7F7aOvQCXSDAo9QTlyf7BhXEsZymLUvF0O1yU9Q9wvrjAWn8uVHYnAvgw==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz",
+      "integrity": "sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.1.tgz",
-      "integrity": "sha512-OteRb8WubcmEvU0YlMJwCXs3Q6xrdkb0v50/qZBJP1TF0CvujFZQM++9BjEkTER/Jr9wbPHvjSFKnbMta0b4dQ==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
+      "integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -146,81 +146,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.1.tgz",
-      "integrity": "sha512-0GmfSgDQK6oiIVXnJvGxtNFOfosBspRTR7csCOYCTL1P8QtxX2vDCIKwTM7xdSAEbJaZ43QlWg25q0Qdsndz8Q==",
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.2.tgz",
+      "integrity": "sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.1.tgz",
-      "integrity": "sha512-ySuigKEe4YjYV3si8NVk9BHQpFj/1B+ON7DhhvTvbrZJseHQQloxzq0yHwKmznSdlO6C956fx4pcfOKkZClsyg==",
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.2.tgz",
+      "integrity": "sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.1.tgz",
-      "integrity": "sha512-Cp8T/B0gVmjFlzzp6eP47hwKh5FGyeqQp1N48/ANDdvdiQkPqLyFHQVDwLBH0LddfIPQE+yqmZIgmKc82haF4A==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.2.tgz",
+      "integrity": "sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.1.tgz",
-      "integrity": "sha512-XKdGGLikfrlK66ZSXh/vWcXZZ8Vg3byDFbJD8pwEvN1FoBRGxhxya476IY2ohoTymLa4qB5LBRlIa+2TLHx3Uw==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz",
+      "integrity": "sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.1.tgz",
-      "integrity": "sha512-mBAU6WyVsDwhHyGM+nodt1/oebHxgvuLlOAoMGbj/1i6LygDHZWDgL1t5JEs37x9Aywv7ZGhqbM1GsfZ54sU6g==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz",
+      "integrity": "sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.1.tgz",
-      "integrity": "sha512-qmo1LXrNKLHvJE6mdQbLnsZAoZvj7VyF2ft4xmbSGWI2WWm87fx/CjUX4kEExt4y0a6T6nEts6ofpUfH5TEE1A==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz",
+      "integrity": "sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.1"
+        "@algolia/client-common": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -994,25 +994,25 @@
       "license": "ISC"
     },
     "node_modules/algoliasearch": {
-      "version": "5.50.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.1.tgz",
-      "integrity": "sha512-/bwdue1/8LWELn/DBalGRfuLsXBLXULJo/yOeavJtDu8rBwxIzC6/Rz9Jg19S21VkJvRuZO1k8CZXBMS73mYbA==",
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
+      "integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.16.1",
-        "@algolia/client-abtesting": "5.50.1",
-        "@algolia/client-analytics": "5.50.1",
-        "@algolia/client-common": "5.50.1",
-        "@algolia/client-insights": "5.50.1",
-        "@algolia/client-personalization": "5.50.1",
-        "@algolia/client-query-suggestions": "5.50.1",
-        "@algolia/client-search": "5.50.1",
-        "@algolia/ingestion": "1.50.1",
-        "@algolia/monitoring": "1.50.1",
-        "@algolia/recommend": "5.50.1",
-        "@algolia/requester-browser-xhr": "5.50.1",
-        "@algolia/requester-fetch": "5.50.1",
-        "@algolia/requester-node-http": "5.50.1"
+        "@algolia/abtesting": "1.16.2",
+        "@algolia/client-abtesting": "5.50.2",
+        "@algolia/client-analytics": "5.50.2",
+        "@algolia/client-common": "5.50.2",
+        "@algolia/client-insights": "5.50.2",
+        "@algolia/client-personalization": "5.50.2",
+        "@algolia/client-query-suggestions": "5.50.2",
+        "@algolia/client-search": "5.50.2",
+        "@algolia/ingestion": "1.50.2",
+        "@algolia/monitoring": "1.50.2",
+        "@algolia/recommend": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -2056,9 +2056,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-20.0.1.tgz",
-      "integrity": "sha512-YuzpyL1Od5dJzpeETVh2H5o1I8tpi0zkf6v7k7rXwUDfiDliBX9dgVIb7FlEfp8Lu2RtECAv63ZHm/rqpIhYsw==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-21.0.2.tgz",
+      "integrity": "sha512-b4o+4hbTOZW1gDPcM3wRpIgaB+Vyn/c6MFG2aw70Mo84f0toUulXUJtA1cncBv5BEZqUyotHFv6FR7aIN3Sq1w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2066,8 +2066,8 @@
         "npm-check-updates": "build/cli.js"
       },
       "engines": {
-        "node": ">=20.0.0",
-        "npm": ">=8.12.1"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/object-inspect": {
@@ -2236,9 +2236,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     }
   },
   "dependencies": {
-    "@algolia/client-search": "^5.50.1",
-    "algoliasearch": "^5.50.1",
+    "@algolia/client-search": "^5.50.2",
+    "algoliasearch": "^5.50.2",
     "instantsearch.js": "^4.93.0"
   },
   "devDependencies": {
@@ -23,8 +23,8 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.2",
     "lint-staged": "^16.4.0",
-    "npm-check-updates": "^20.0.1",
-    "prettier": "^3.8.2",
+    "npm-check-updates": "^21.0.2",
+    "prettier": "^3.8.3",
     "prettier-plugin-go-template": "^0.0.15",
     "vitest": "^4.1.4"
   },
@@ -41,7 +41,7 @@
     "prepare": "husky",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "update": "ncu -u && npm install"
+    "update": "ncu -u && npm install --ignore-scripts"
   },
   "version": "1.2.3"
 }


### PR DESCRIPTION
## Overview

This PR hardens the npm dependency update workflow against supply chain risks and updates dependencies using the hardened flow.

## Changes

- [x] Added repository-local npm hardening config in `.npmrc` (`ignore-scripts=true`, `min-release-age=7`)
- [x] Added Dependabot cooldown (`default-days: 7`) in `.github/dependabot.yml`
- [x] Updated npm update workflow and dependency versions via `npm run update`

## Related Issues

N/A

## Screenshots

N/A (no UI changes)

## Testing

- [x] Conducted manual testing
- [x] `npm run update`
- [x] `npm test`
- [x] `cd exampleSite && hugo --gc --minify`

## Checklist

- [x] I have followed the code style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation (if necessary)
- [x] I have added appropriate labels to this pull request

## Additional Comments

- This follows the defense-in-depth approach described in the referenced Qiita article:
  - lifecycle script blocking on install/update
  - minimum package age gate
  - cooldown gate for Dependabot npm updates
