### PR TITLE
docs: add release workflow skill and governance rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,8 +13,12 @@ These instructions define how AI coding assistants should work in this repositor
 - Do not refactor unrelated code while implementing a request.
 - Do not introduce new frameworks or large dependencies unless explicitly requested.
 - Write all commit messages, PR text, and generated docs in English unless the user asks otherwise.
+- Write all skill files (`.github/skills/**/SKILL.md`) in English.
 - When reviewing changes (including pull requests), read `.github/prompts/review.prompt.md` first and follow its checklist and output format.
 - When you need to understand folder or file placement, read `docs/develop/project-structure.md` first and follow its structure guidance.
+- Direct merges to `main` and `dev` are not allowed; merge only through Pull Requests.
+- Release and tag work must be done on a branch derived from `dev`, then submitted as a Pull Request targeting `dev`.
+- Release operations must use tags in `vX.Y.Z` format, and `package.json` version must be updated to `X.Y.Z` before tagging.
 
 ## Hugo / Template Guidelines
 - Prefer Hugo built-in functions and existing partial structure.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@ These instructions define how AI coding assistants should work in this repositor
 - Do not refactor unrelated code while implementing a request.
 - Do not introduce new frameworks or large dependencies unless explicitly requested.
 - Write all commit messages, PR text, and generated docs in English unless the user asks otherwise.
-- Write all skill files (`.github/skills/**/SKILL.md`) in English.
+- Write skill files (`.github/skills/**/SKILL.md`) primarily in English; non-English trigger examples are allowed when they improve usability or reflect existing behavior.
 - When reviewing changes (including pull requests), read `.github/prompts/review.prompt.md` first and follow its checklist and output format.
 - When you need to understand folder or file placement, read `docs/develop/project-structure.md` first and follow its structure guidance.
 - Direct merges to `main` and `dev` are not allowed; merge only through Pull Requests.

--- a/.github/skills/github-release-versioning/SKILL.md
+++ b/.github/skills/github-release-versioning/SKILL.md
@@ -21,7 +21,6 @@ argument-hint: "Target version, for example v1.2.5"
 ## Inputs
 - targetVersion: required, must follow vX.Y.Z format (e.g., v1.2.3).
 - releaseBranch: optional, defaults to chore/release-vX-Y-Z derived from targetVersion (e.g., chore/release-v1-2-3).
-- preRelease: optional, true or false.
 
 ## Decision Rules
 1. Validate targetVersion with pattern ^v[0-9]+\.[0-9]+\.[0-9]+$.
@@ -56,5 +55,4 @@ argument-hint: "Target version, for example v1.2.5"
 
 ## Example Prompts
 - Run release workflow for v1.2.5.
-- Prepare a prerelease v1.3.0 from dev and open a Pull Request.
 - Update package.json and create tag v2.0.0, then push and draft release.

--- a/.github/skills/github-release-versioning/SKILL.md
+++ b/.github/skills/github-release-versioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-release-versioning
-description: "Release workflow for publishing a new GitHub version. Use when updating package.json version, creating a vx.x.x tag, and preparing a Pull Request to dev for release."
+description: "Release workflow for publishing a new GitHub version. Use when updating package.json version, creating a vX.Y.Z tag, and preparing a Pull Request to dev for release."
 argument-hint: "Target version, for example v1.2.5"
 ---
 
@@ -19,8 +19,8 @@ argument-hint: "Target version, for example v1.2.5"
 - Release and tag work must be done on a branch derived from dev, then submitted as a Pull Request targeting dev.
 
 ## Inputs
-- targetVersion: required, must follow vx.x.x format.
-- releaseBranch: optional, defaults to chore/release-vx-x-x.
+- targetVersion: required, must follow vX.Y.Z format (e.g., v1.2.3).
+- releaseBranch: optional, defaults to chore/release-vX-Y-Z derived from targetVersion (e.g., chore/release-v1-2-3).
 - preRelease: optional, true or false.
 
 ## Decision Rules

--- a/.github/skills/github-release-versioning/SKILL.md
+++ b/.github/skills/github-release-versioning/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: github-release-versioning
+description: "Release workflow for publishing a new GitHub version. Use when updating package.json version, creating a vx.x.x tag, and preparing a Pull Request to dev for release."
+argument-hint: "Target version, for example v1.2.5"
+---
+
+# GitHub Release Versioning
+
+## Purpose
+- Standardize release preparation and publication for this repository.
+- Keep package version, git tag, and GitHub Release consistent.
+
+## Language Rule
+- Write all skill outputs, commit messages, Pull Request descriptions, and release notes in English.
+
+## Repository Governance
+- Direct merges to main and dev are not allowed.
+- Merge changes to main and dev only through Pull Requests.
+- Release and tag work must be done on a branch derived from dev, then submitted as a Pull Request targeting dev.
+
+## Inputs
+- targetVersion: required, must follow vx.x.x format.
+- releaseBranch: optional, defaults to chore/release-vx-x-x.
+- preRelease: optional, true or false.
+
+## Decision Rules
+1. Validate targetVersion with pattern ^v[0-9]+\.[0-9]+\.[0-9]+$.
+2. Abort if the working tree is not clean.
+3. Abort if current branch is main or dev.
+4. Abort if the release branch is not derived from dev.
+5. Abort if target tag already exists locally or on remote.
+
+## Procedure
+1. Create a release branch from dev.
+2. Update package.json version to X.Y.Z (remove leading v from targetVersion).
+3. Run validation checks required by repository policy.
+4. Commit release preparation changes.
+5. Create an annotated tag named vX.Y.Z.
+6. Push release branch and tag.
+7. Open a Pull Request with base dev and head release branch.
+8. After PR is merged, create a GitHub Release for vX.Y.Z.
+
+## Validation Checklist
+- package.json version matches targetVersion without leading v.
+- Tag name matches targetVersion and is annotated.
+- Branch and tag are pushed successfully.
+- Pull Request to dev is open or merged.
+- GitHub Release exists for targetVersion.
+
+## Failure Handling
+- Invalid targetVersion: stop and request a valid vx.x.x value.
+- Dirty working tree: stop and ask to commit or stash changes.
+- Existing tag: stop and bump to the next version.
+- Wrong branch origin: recreate branch from dev.
+- Failed push or release creation: stop, report error, and retry from the failed step.
+
+## Example Prompts
+- Run release workflow for v1.2.5.
+- Prepare a prerelease v1.3.0 from dev and open a Pull Request.
+- Update package.json and create tag v2.0.0, then push and draft release.

--- a/.github/skills/github-release-versioning/SKILL.md
+++ b/.github/skills/github-release-versioning/SKILL.md
@@ -48,7 +48,7 @@ argument-hint: "Target version, for example v1.2.5"
 - GitHub Release exists for targetVersion.
 
 ## Failure Handling
-- Invalid targetVersion: stop and request a valid vx.x.x value.
+- Invalid targetVersion: stop and request a valid vX.Y.Z value.
 - Dirty working tree: stop and ask to commit or stash changes.
 - Existing tag: stop and bump to the next version.
 - Wrong branch origin: recreate branch from dev.


### PR DESCRIPTION
## Overview

Add a new release workflow skill and repository governance rules for branch protection and version/tag consistency.

## Changes

- [x] Add `.github/skills/github-release-versioning/SKILL.md` to standardize GitHub release operations
- [x] Update `.github/copilot-instructions.md` with branch governance rules (`main`/`dev` via PR only)
- [x] Add release constraints: release branch must derive from `dev`, tag format `vX.Y.Z`, and `package.json` version alignment

## Related Issues

N/A

## Screenshots

N/A (documentation-only changes)

## Testing

- [x] Conducted manual testing
- [x] Verified local tests: `npm test`

## Checklist

- [x] I have followed the code style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation (if necessary)
- [x] I have added appropriate labels to this pull request

## Additional Comments

- All skill content is written in English as requested.
- No runtime behavior changes are included in this PR.
