### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/.github/skills/github-release-versioning/SKILL.md
+++ b/.github/skills/github-release-versioning/SKILL.md
@@ -9,6 +9,7 @@ argument-hint: "Target version, for example v1.2.5"
 ## Purpose
 - Standardize release preparation and publication for this repository.
 - Keep package version, git tag, and GitHub Release consistent.
+- Use `npm version` to update `package.json` and create the release tag in one operation.
 
 ## Language Rule
 - Write all skill outputs, commit messages, Pull Request descriptions, and release notes in English.
@@ -28,20 +29,23 @@ argument-hint: "Target version, for example v1.2.5"
 3. Abort if current branch is main or dev.
 4. Abort if the release branch is not derived from dev.
 5. Abort if target tag already exists locally or on remote.
+6. Abort if `npm config get tag-version-prefix` is not `v`.
+7. Derive bareVersion by removing the leading `v` from targetVersion.
 
 ## Procedure
 1. Create a release branch from dev.
-2. Update package.json version to X.Y.Z (remove leading v from targetVersion).
-3. Run validation checks required by repository policy.
-4. Commit release preparation changes.
-5. Create an annotated tag named vX.Y.Z.
+2. Derive bareVersion (X.Y.Z) from targetVersion (vX.Y.Z).
+3. Run `npm version "${bareVersion}" -m "chore(release): v%s"`.
+4. Confirm `package.json` is updated and git tag `vX.Y.Z` is created by `npm version`.
+5. Run validation checks required by repository policy.
 6. Push release branch and tag.
 7. Open a Pull Request with base dev and head release branch.
 8. After PR is merged, create a GitHub Release for vX.Y.Z.
 
 ## Validation Checklist
 - package.json version matches targetVersion without leading v.
-- Tag name matches targetVersion and is annotated.
+- Tag name matches targetVersion.
+- Release commit message follows `chore(release): vX.Y.Z`.
 - Branch and tag are pushed successfully.
 - Pull Request to dev is open or merged.
 - GitHub Release exists for targetVersion.
@@ -50,9 +54,11 @@ argument-hint: "Target version, for example v1.2.5"
 - Invalid targetVersion: stop and request a valid vX.Y.Z value.
 - Dirty working tree: stop and ask to commit or stash changes.
 - Existing tag: stop and bump to the next version.
+- Invalid npm tag prefix: set `npm config set tag-version-prefix v` and retry.
 - Wrong branch origin: recreate branch from dev.
 - Failed push or release creation: stop, report error, and retry from the failed step.
 
 ## Example Prompts
 - Run release workflow for v1.2.5.
+- Run minor release workflow for v1.3.0 using npm version.
 - Update package.json and create tag v2.0.0, then push and draft release.

--- a/.github/skills/github-release-versioning/SKILL.md
+++ b/.github/skills/github-release-versioning/SKILL.md
@@ -29,21 +29,21 @@ argument-hint: "Target version, for example v1.2.5"
 3. Abort if current branch is main or dev.
 4. Abort if the release branch is not derived from dev.
 5. Abort if target tag already exists locally or on remote.
-6. Abort if `npm config get tag-version-prefix` is not `v`.
-7. Derive bareVersion by removing the leading `v` from targetVersion.
+6. Derive bareVersion by removing the leading `v` from targetVersion.
 
 ## Procedure
 1. Create a release branch from dev.
 2. Derive bareVersion (X.Y.Z) from targetVersion (vX.Y.Z).
-3. Run `npm version "${bareVersion}" -m "chore(release): v%s"`.
-4. Confirm `package.json` is updated and git tag `vX.Y.Z` is created by `npm version`.
-5. Run validation checks required by repository policy.
+3. Run validation checks required by repository policy.
+4. Run `npm version "${bareVersion}" --tag-version-prefix v -m "chore(release): v%s"`.
+5. Confirm `package.json` and `package-lock.json` are updated and git tag `vX.Y.Z` is created by `npm version`.
 6. Push release branch and tag.
 7. Open a Pull Request with base dev and head release branch.
 8. After PR is merged, create a GitHub Release for vX.Y.Z.
 
 ## Validation Checklist
 - package.json version matches targetVersion without leading v.
+- package-lock.json version matches package.json.
 - Tag name matches targetVersion.
 - Release commit message follows `chore(release): vX.Y.Z`.
 - Branch and tag are pushed successfully.
@@ -54,7 +54,6 @@ argument-hint: "Target version, for example v1.2.5"
 - Invalid targetVersion: stop and request a valid vX.Y.Z value.
 - Dirty working tree: stop and ask to commit or stash changes.
 - Existing tag: stop and bump to the next version.
-- Invalid npm tag prefix: set `npm config set tag-version-prefix v` and retry.
 - Wrong branch origin: recreate branch from dev.
 - Failed push or release creation: stop, report error, and retry from the failed step.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "HikaeMe",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.4",
+      "version": "1.3.0",
       "dependencies": {
         "@algolia/client-search": "^5.50.2",
         "algoliasearch": "^5.50.2",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "test:e2e": "playwright test",
     "update": "ncu -u && npm install --ignore-scripts"
   },
-  "version": "1.2.4"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
## Overview

Prepare minor release `v1.3.0` from a branch derived from `dev` and update the release skill to use `npm version` for synchronized package and tag operations.

## Changes

- [x] Bump `package.json` version from `1.2.4` to `1.3.0` via `npm version`
- [x] Create and push release tag `v1.3.0`
- [x] Update `.github/skills/github-release-versioning/SKILL.md` to document `npm version` workflow

## Related Issues

N/A

## Screenshots

N/A (no UI changes)

## Testing

- [x] Conducted manual testing
- [x] `npm test`
- [x] `cd exampleSite && hugo --gc --minify`

## Checklist

- [x] I have followed the code style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation (if necessary)
- [x] I have added appropriate labels to this pull request

## Additional Comments

- Work was performed on `chore/release-v1-3-0`, derived from `dev`, per repository governance.
- Tag format follows `vX.Y.Z` policy.
