### PR TITLE
docs: simplify GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,38 +2,23 @@
 name: Bug report
 about: Create a report to help us improve
 title: ""
-labels: ""
+labels: "bug"
 assignees: ""
 ---
 
-**Describe the bug** (required)
+**Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce** (required)
-Steps to reproduce the behavior:
+**To Reproduce**
+Steps to reproduce the behavior, including relevant config snippets or content examples.
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-If you have screenshots, provide here.
-
-**Expected behavior** (optional)
+**Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Desktop (please complete the following information):** (optional)
+**Environment**
 
-- OS: [e.g. iOS]
-- Browser [e.g. chrome, safari]
-- Version [e.g. 22]
+- Hugo version: [e.g. 0.157.0]
+- OS / Browser: [e.g. macOS, Chrome 120]
 
-**Smartphone (please complete the following information):** (optional)
-
-- Device: [e.g. iPhone6]
-- OS: [e.g. iOS8.1]
-- Browser [e.g. stock browser, safari]
-- Version [e.g. 22]
-
-**Additional context** (optional)
-Add any other context about the problem here.
+**Additional context**
+Screenshots, logs, or any other context.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,18 +2,18 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ""
-labels: ""
+labels: "enhancement"
 assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Problem / Goal**
+What problem does this solve, or what goal does it support?
 
-**Describe the solution you'd like**
+**Proposed solution**
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Alternatives considered**
+Any alternative approaches you've thought about.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Screenshots, links, or any other relevant context.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,22 @@
 ## Overview
 
-Please provide a brief description of the purpose and changes in this pull request.
+<!-- What does this PR change and why? -->
 
 ## Changes
 
-- [ ] Change 1
-- [ ] Change 2
-- [ ] Change 3
+<!-- Summarize the key changes -->
 
 ## Related Issues
 
-If there are any related issues, please link them here.
-
-## Screenshots
-
-If there are UI changes, please attach before and after screenshots.
-
-## Testing
-
-- [ ] Conducted manual testing
+<!-- Link related issues, e.g. Closes #123 -->
 
 ## Checklist
 
-- [ ] I have followed the code style guidelines
-- [ ] I have performed a self-review of my code
-- [ ] I have updated the documentation (if necessary)
-- [ ] I have added appropriate labels to this pull request
+- [ ] Self-review done (following `review.prompt.md`)
+- [ ] Hugo production build passes: `cd exampleSite && hugo --gc --minify`
+- [ ] Docs updated if behavior changed
+- [ ] No unrelated changes included
 
-## Additional Comments
+## Notes for Reviewers
 
-Please add any special instructions for reviewers or points that need discussion here.
+<!-- Special instructions, discussion points, or known limitations -->


### PR DESCRIPTION
## Overview

Simplify the GitHub issue and PR templates to reduce noise and align with this project's actual workflow.

## Changes

- **PULL_REQUEST_TEMPLATE.md**: Removed redundant Screenshots and Testing sections; updated checklist to reference `review.prompt.md` and the Hugo build command explicitly
- **ISSUE_TEMPLATE/bug_report.md**: Merged Desktop/Smartphone sections into a single Environment section (added Hugo version field); set default label to `bug`
- **ISSUE_TEMPLATE/feature_request.md**: Shortened section headings; set default label to `enhancement`

## Related Issues

None

## Checklist

- [x] Self-review done (following `review.prompt.md`)
- [x] Hugo production build passes: `cd exampleSite && hugo --gc --minify`
- [x] Docs updated if behavior changed
- [x] No unrelated changes included

## Notes for Reviewers

Template-only changes; no build or runtime impact.