### PR TITLE
docs: add getting-started guidance files for all supported languages

### DIFF
--- a/.github/skills/documentation-maintenance/SKILL.md
+++ b/.github/skills/documentation-maintenance/SKILL.md
@@ -79,6 +79,8 @@ If uncertainty remains, ask focused clarification before editing.
 2. In guides, prefer links to shared examples over duplicated code blocks
 3. Keep edits minimal where possible, but allow section reorganization when readability improves
 4. Preserve bilingual parity for paired docs when applicable
+5. When adding locale-specific docs with untranslated bodies, add a clear placeholder note near the top to avoid misleading readers
+6. Use native language labels in locale document headings where practical (for example, `हिन्दी`, `한국어`, `简体中文`, `繁體中文`)
 
 ### Phase 4: Implementation
 
@@ -138,6 +140,13 @@ When setup snippets repeat in multiple guides:
 1. Move canonical snippets to `docs/guidance/assets/*`
 2. Link from each guide section to the canonical file
 3. Keep local guide text concise and task-oriented
+
+### Pattern D: Locale docs with placeholder content
+
+When adding language-specific guide files before full translation is ready:
+1. Keep heading language label consistent with native naming conventions
+2. Add a short note near the top that the body is currently an English placeholder
+3. Reflect this status in `README.md` documentation index if relevant
 
 ---
 

--- a/.github/skills/feature-implementation/SKILL.md
+++ b/.github/skills/feature-implementation/SKILL.md
@@ -114,6 +114,8 @@ User Responses:
 
 ## Documentation (if needed)
 - [ ] Update README.md or relevant docs if user-facing
+- [ ] For locale-specific docs, use native heading labels and add placeholder notes when content is not yet translated
+- [ ] Keep README documentation index aligned with newly added locale guide files
 - [ ] Add comments to complex code sections
 
 ## Pull Request

--- a/README.md
+++ b/README.md
@@ -10,7 +10,16 @@ A simple theme that displays only the bare minimum of elements readers need.
 
 - [English](./docs/guidance/getting-started.en.md)
 - [日本語](./docs/guidance/getting-started.ja.md)
+- [Deutsch](./docs/guidance/getting-started.de.md)
+- [Español](./docs/guidance/getting-started.es.md)
+- [Français](./docs/guidance/getting-started.fr.md)
+- [हिन्दी](./docs/guidance/getting-started.hi.md)
+- [한국어](./docs/guidance/getting-started.ko.md)
+- [简体中文](./docs/guidance/getting-started.zh-cn.md)
+- [繁體中文](./docs/guidance/getting-started.zh-tw.md)
 - [Troubleshooting](./docs/guidance/troubleshooting.md)
+
+Note: Some newly added language guides are temporary English placeholders and are marked in each file.
 
 ### Develop (for contributors/developers/AI)
 

--- a/docs/guidance/getting-started.de.md
+++ b/docs/guidance/getting-started.de.md
@@ -1,5 +1,7 @@
 # Getting Started (Deutsch)
 
+> Note: This locale-specific guide is currently an English placeholder. A full German translation will be added in a follow-up update.
+
 This guide explains how to set up a new Hugo site with the HikaeMe theme.
 
 ## Prerequisites

--- a/docs/guidance/getting-started.de.md
+++ b/docs/guidance/getting-started.de.md
@@ -1,0 +1,258 @@
+# Getting Started (Deutsch)
+
+This guide explains how to set up a new Hugo site with the HikaeMe theme.
+
+## Prerequisites
+
+Prepare the following tools:
+
+- [Hugo](https://gohugo.io/installation/)
+- [Go](https://golang.org/doc/install) (required for Hugo modules)
+- [Git](https://git-scm.com/)
+- [Node.js and npm](https://nodejs.org/)
+- GCC (required for compiling native dependencies)
+- Sass (SCSS compiler)
+
+For VS Code users (optional), sample dev container files are available here:
+
+- [devcontainer.json example](./assets/devcontainer.json)
+- [postCreateCommand.sh example](./assets/postCreateCommand.sh)
+
+Copy these files into a `.devcontainer/` directory (for example `.devcontainer/devcontainer.json` and `.devcontainer/postCreateCommand.sh`) so VS Code can detect and use them.
+Verify your environment:
+
+```bash
+hugo version
+go version
+git --version
+node --version
+npm --version
+gcc --version
+```
+
+## Setup Steps
+
+### Create a New Hugo Site
+
+```bash
+hugo new site my-blog --format yaml
+cd my-blog
+git init
+```
+
+### Initialize Your Site as a Hugo Module
+
+```bash
+hugo mod init github.com/yourusername/my-blog
+```
+
+This registers your site as a module. The module path does not need to match your final repository name, but it must be unique.
+
+### Add HikaeMe as a Module Dependency
+
+Add the module import to your site configuration. For a single-file setup, edit `hugo.yaml` and add:
+
+```yaml
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+```
+
+If you use a split configuration directory, place the same block in `config/_default/module.yaml`.
+
+### Download Theme Dependencies
+
+```bash
+hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod npm pack
+npm install
+```
+
+### Configuration Layout
+
+You can use either of these layouts:
+
+- Single-file config for small sites: `hugo.yaml`
+- Split config for larger sites: `config/_default/`
+
+This repository uses `config/_default/` to keep large settings manageable. A typical split layout looks like this:
+
+```text
+config/_default/
+  hugo.yaml
+  module.yaml
+  params.yaml
+  menus.yaml
+  outputs.yaml
+  outputFormats.yaml
+  permalinks.yaml
+```
+
+### Start the Development Server
+
+```bash
+hugo server -D
+```
+
+Open `http://localhost:1313` in your browser.
+
+## Minimal Configuration Example (`hugo.yaml`)
+
+```yaml
+title: "My Blog"
+baseURL: "https://example.com/"
+languageCode: "ja"
+
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+
+params:
+  author: "Your Name"
+  description: "My personal blog"
+```
+
+This guide uses a single `hugo.yaml` for brevity. If you prefer to split your configuration into multiple files, see [exampleSite/config/_default/](../../exampleSite/config/_default/) for a working example.
+
+## Multilingual Setup
+
+HikaeMe supports Hugo multilingual sites.
+
+- Recommended setup: single host with the default language at the root
+- Existing default-language URLs can remain canonical
+- Secondary languages can live under prefixes such as `/en/`
+- UI strings can be managed in `i18n/ja.yaml`, `i18n/en.yaml`, and other language files
+
+Example:
+
+```yaml
+defaultContentLanguage: "ja"
+defaultContentLanguageInSubdir: false
+
+languages:
+  ja:
+    languageCode: "ja-JP"
+    languageName: "Japanese"
+    weight: 1
+  en:
+    languageCode: "en-US"
+    languageName: "English"
+    weight: 2
+```
+
+Hugo will fall back to global configuration values for keys not defined inside a language block, which makes it practical to localize only the settings that differ.
+
+## Algolia Search with Multilingual Sites
+
+### Output path behavior
+
+Algolia JSON is generated at the **home** kind. Its output path depends on `defaultContentLanguageInSubdir`:
+
+| `defaultContentLanguageInSubdir` | Default language | Other languages |
+|---|---|---|
+| `false` (default) | `/algolia.json` | `/en/algolia.json` |
+| `true` | `/<defaultLang>/algolia.json` | `/en/algolia.json` |
+
+With `false`, the root `/algolia.json` is the default-language index. This is expected Hugo behavior, not a bug. In this documentation's sample config, `defaultContentLanguage: "ja"`, so with `true` the default-language output path becomes `/ja/algolia.json`.
+
+### Required config
+
+**`config/_default/outputFormats.yaml`**
+
+```yaml
+Algolia:
+  baseName: "algolia"
+  isPlainText: true
+  mediaType: "application/json"
+  notAlternative: true
+```
+
+**`config/_default/outputs.yaml`**
+
+```yaml
+home:
+  - "HTML"
+  - "Algolia"
+section:
+  - "HTML"
+```
+
+Generate only at `home`, not `section`, to avoid duplicate records.
+
+**`config/_default/params.yaml`**
+
+```yaml
+enableAlgolia: true
+
+algolia:
+  appId: "YOUR_APP_ID"
+  searchOnlyApiKey: "YOUR_SEARCH_ONLY_API_KEY"
+  indexName: "YOUR_INDEX_NAME"
+  vars:
+    - "title"
+    - "summary"
+    - "date"
+    - "permalink"
+  params:
+    - "tags"
+    - "categories"
+```
+
+### Per-language index names
+
+To use separate Algolia indexes per language, override `indexName` in the language block:
+
+```yaml
+languages:
+  ja:
+    params:
+      algolia:
+        indexName: YOUR_JA_INDEX
+  en:
+    params:
+      algolia:
+        indexName: YOUR_EN_INDEX
+```
+
+### Content organization by language
+
+When using many languages, organizing content by language directory is easier to
+maintain than filename suffixes.
+
+Add `contentDir` for each language in `languages` config:
+
+```yaml
+languages:
+  ja:
+    contentDir: content/ja
+  en:
+    contentDir: content/en
+```
+
+```text
+content/
+  ja/
+    posts/
+      tech/
+        article1.md
+    about.md
+  en/
+    posts/
+      tech/
+        article1.md
+    about.md
+```
+
+### Verifying the output
+
+```bash
+cd exampleSite && hugo --gc --minify
+
+# record counts (both should be non-zero)
+jq 'length' public/algolia.json
+jq 'length' public/en/algolia.json
+
+# confirm no cross-language contamination
+jq '[.[].permalink | contains("/en/")] | any' public/algolia.json   # expect false
+jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json  # expect true
+```

--- a/docs/guidance/getting-started.es.md
+++ b/docs/guidance/getting-started.es.md
@@ -1,5 +1,7 @@
 # Getting Started (Español)
 
+> Note: This locale-specific guide is currently an English placeholder. A full Spanish translation will be added in a follow-up update.
+
 This guide explains how to set up a new Hugo site with the HikaeMe theme.
 
 ## Prerequisites

--- a/docs/guidance/getting-started.es.md
+++ b/docs/guidance/getting-started.es.md
@@ -1,0 +1,258 @@
+# Getting Started (Español)
+
+This guide explains how to set up a new Hugo site with the HikaeMe theme.
+
+## Prerequisites
+
+Prepare the following tools:
+
+- [Hugo](https://gohugo.io/installation/)
+- [Go](https://golang.org/doc/install) (required for Hugo modules)
+- [Git](https://git-scm.com/)
+- [Node.js and npm](https://nodejs.org/)
+- GCC (required for compiling native dependencies)
+- Sass (SCSS compiler)
+
+For VS Code users (optional), sample dev container files are available here:
+
+- [devcontainer.json example](./assets/devcontainer.json)
+- [postCreateCommand.sh example](./assets/postCreateCommand.sh)
+
+Copy these files into a `.devcontainer/` directory (for example `.devcontainer/devcontainer.json` and `.devcontainer/postCreateCommand.sh`) so VS Code can detect and use them.
+Verify your environment:
+
+```bash
+hugo version
+go version
+git --version
+node --version
+npm --version
+gcc --version
+```
+
+## Setup Steps
+
+### Create a New Hugo Site
+
+```bash
+hugo new site my-blog --format yaml
+cd my-blog
+git init
+```
+
+### Initialize Your Site as a Hugo Module
+
+```bash
+hugo mod init github.com/yourusername/my-blog
+```
+
+This registers your site as a module. The module path does not need to match your final repository name, but it must be unique.
+
+### Add HikaeMe as a Module Dependency
+
+Add the module import to your site configuration. For a single-file setup, edit `hugo.yaml` and add:
+
+```yaml
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+```
+
+If you use a split configuration directory, place the same block in `config/_default/module.yaml`.
+
+### Download Theme Dependencies
+
+```bash
+hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod npm pack
+npm install
+```
+
+### Configuration Layout
+
+You can use either of these layouts:
+
+- Single-file config for small sites: `hugo.yaml`
+- Split config for larger sites: `config/_default/`
+
+This repository uses `config/_default/` to keep large settings manageable. A typical split layout looks like this:
+
+```text
+config/_default/
+  hugo.yaml
+  module.yaml
+  params.yaml
+  menus.yaml
+  outputs.yaml
+  outputFormats.yaml
+  permalinks.yaml
+```
+
+### Start the Development Server
+
+```bash
+hugo server -D
+```
+
+Open `http://localhost:1313` in your browser.
+
+## Minimal Configuration Example (`hugo.yaml`)
+
+```yaml
+title: "My Blog"
+baseURL: "https://example.com/"
+languageCode: "ja"
+
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+
+params:
+  author: "Your Name"
+  description: "My personal blog"
+```
+
+This guide uses a single `hugo.yaml` for brevity. If you prefer to split your configuration into multiple files, see [exampleSite/config/_default/](../../exampleSite/config/_default/) for a working example.
+
+## Multilingual Setup
+
+HikaeMe supports Hugo multilingual sites.
+
+- Recommended setup: single host with the default language at the root
+- Existing default-language URLs can remain canonical
+- Secondary languages can live under prefixes such as `/en/`
+- UI strings can be managed in `i18n/ja.yaml`, `i18n/en.yaml`, and other language files
+
+Example:
+
+```yaml
+defaultContentLanguage: "ja"
+defaultContentLanguageInSubdir: false
+
+languages:
+  ja:
+    languageCode: "ja-JP"
+    languageName: "Japanese"
+    weight: 1
+  en:
+    languageCode: "en-US"
+    languageName: "English"
+    weight: 2
+```
+
+Hugo will fall back to global configuration values for keys not defined inside a language block, which makes it practical to localize only the settings that differ.
+
+## Algolia Search with Multilingual Sites
+
+### Output path behavior
+
+Algolia JSON is generated at the **home** kind. Its output path depends on `defaultContentLanguageInSubdir`:
+
+| `defaultContentLanguageInSubdir` | Default language | Other languages |
+|---|---|---|
+| `false` (default) | `/algolia.json` | `/en/algolia.json` |
+| `true` | `/<defaultLang>/algolia.json` | `/en/algolia.json` |
+
+With `false`, the root `/algolia.json` is the default-language index. This is expected Hugo behavior, not a bug. In this documentation's sample config, `defaultContentLanguage: "ja"`, so with `true` the default-language output path becomes `/ja/algolia.json`.
+
+### Required config
+
+**`config/_default/outputFormats.yaml`**
+
+```yaml
+Algolia:
+  baseName: "algolia"
+  isPlainText: true
+  mediaType: "application/json"
+  notAlternative: true
+```
+
+**`config/_default/outputs.yaml`**
+
+```yaml
+home:
+  - "HTML"
+  - "Algolia"
+section:
+  - "HTML"
+```
+
+Generate only at `home`, not `section`, to avoid duplicate records.
+
+**`config/_default/params.yaml`**
+
+```yaml
+enableAlgolia: true
+
+algolia:
+  appId: "YOUR_APP_ID"
+  searchOnlyApiKey: "YOUR_SEARCH_ONLY_API_KEY"
+  indexName: "YOUR_INDEX_NAME"
+  vars:
+    - "title"
+    - "summary"
+    - "date"
+    - "permalink"
+  params:
+    - "tags"
+    - "categories"
+```
+
+### Per-language index names
+
+To use separate Algolia indexes per language, override `indexName` in the language block:
+
+```yaml
+languages:
+  ja:
+    params:
+      algolia:
+        indexName: YOUR_JA_INDEX
+  en:
+    params:
+      algolia:
+        indexName: YOUR_EN_INDEX
+```
+
+### Content organization by language
+
+When using many languages, organizing content by language directory is easier to
+maintain than filename suffixes.
+
+Add `contentDir` for each language in `languages` config:
+
+```yaml
+languages:
+  ja:
+    contentDir: content/ja
+  en:
+    contentDir: content/en
+```
+
+```text
+content/
+  ja/
+    posts/
+      tech/
+        article1.md
+    about.md
+  en/
+    posts/
+      tech/
+        article1.md
+    about.md
+```
+
+### Verifying the output
+
+```bash
+cd exampleSite && hugo --gc --minify
+
+# record counts (both should be non-zero)
+jq 'length' public/algolia.json
+jq 'length' public/en/algolia.json
+
+# confirm no cross-language contamination
+jq '[.[].permalink | contains("/en/")] | any' public/algolia.json   # expect false
+jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json  # expect true
+```

--- a/docs/guidance/getting-started.fr.md
+++ b/docs/guidance/getting-started.fr.md
@@ -1,5 +1,7 @@
 # Getting Started (Français)
 
+> Note: This locale-specific guide is currently an English placeholder. A full French translation will be added in a follow-up update.
+
 This guide explains how to set up a new Hugo site with the HikaeMe theme.
 
 ## Prerequisites

--- a/docs/guidance/getting-started.fr.md
+++ b/docs/guidance/getting-started.fr.md
@@ -1,0 +1,258 @@
+# Getting Started (Français)
+
+This guide explains how to set up a new Hugo site with the HikaeMe theme.
+
+## Prerequisites
+
+Prepare the following tools:
+
+- [Hugo](https://gohugo.io/installation/)
+- [Go](https://golang.org/doc/install) (required for Hugo modules)
+- [Git](https://git-scm.com/)
+- [Node.js and npm](https://nodejs.org/)
+- GCC (required for compiling native dependencies)
+- Sass (SCSS compiler)
+
+For VS Code users (optional), sample dev container files are available here:
+
+- [devcontainer.json example](./assets/devcontainer.json)
+- [postCreateCommand.sh example](./assets/postCreateCommand.sh)
+
+Copy these files into a `.devcontainer/` directory (for example `.devcontainer/devcontainer.json` and `.devcontainer/postCreateCommand.sh`) so VS Code can detect and use them.
+Verify your environment:
+
+```bash
+hugo version
+go version
+git --version
+node --version
+npm --version
+gcc --version
+```
+
+## Setup Steps
+
+### Create a New Hugo Site
+
+```bash
+hugo new site my-blog --format yaml
+cd my-blog
+git init
+```
+
+### Initialize Your Site as a Hugo Module
+
+```bash
+hugo mod init github.com/yourusername/my-blog
+```
+
+This registers your site as a module. The module path does not need to match your final repository name, but it must be unique.
+
+### Add HikaeMe as a Module Dependency
+
+Add the module import to your site configuration. For a single-file setup, edit `hugo.yaml` and add:
+
+```yaml
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+```
+
+If you use a split configuration directory, place the same block in `config/_default/module.yaml`.
+
+### Download Theme Dependencies
+
+```bash
+hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod npm pack
+npm install
+```
+
+### Configuration Layout
+
+You can use either of these layouts:
+
+- Single-file config for small sites: `hugo.yaml`
+- Split config for larger sites: `config/_default/`
+
+This repository uses `config/_default/` to keep large settings manageable. A typical split layout looks like this:
+
+```text
+config/_default/
+  hugo.yaml
+  module.yaml
+  params.yaml
+  menus.yaml
+  outputs.yaml
+  outputFormats.yaml
+  permalinks.yaml
+```
+
+### Start the Development Server
+
+```bash
+hugo server -D
+```
+
+Open `http://localhost:1313` in your browser.
+
+## Minimal Configuration Example (`hugo.yaml`)
+
+```yaml
+title: "My Blog"
+baseURL: "https://example.com/"
+languageCode: "ja"
+
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+
+params:
+  author: "Your Name"
+  description: "My personal blog"
+```
+
+This guide uses a single `hugo.yaml` for brevity. If you prefer to split your configuration into multiple files, see [exampleSite/config/_default/](../../exampleSite/config/_default/) for a working example.
+
+## Multilingual Setup
+
+HikaeMe supports Hugo multilingual sites.
+
+- Recommended setup: single host with the default language at the root
+- Existing default-language URLs can remain canonical
+- Secondary languages can live under prefixes such as `/en/`
+- UI strings can be managed in `i18n/ja.yaml`, `i18n/en.yaml`, and other language files
+
+Example:
+
+```yaml
+defaultContentLanguage: "ja"
+defaultContentLanguageInSubdir: false
+
+languages:
+  ja:
+    languageCode: "ja-JP"
+    languageName: "Japanese"
+    weight: 1
+  en:
+    languageCode: "en-US"
+    languageName: "English"
+    weight: 2
+```
+
+Hugo will fall back to global configuration values for keys not defined inside a language block, which makes it practical to localize only the settings that differ.
+
+## Algolia Search with Multilingual Sites
+
+### Output path behavior
+
+Algolia JSON is generated at the **home** kind. Its output path depends on `defaultContentLanguageInSubdir`:
+
+| `defaultContentLanguageInSubdir` | Default language | Other languages |
+|---|---|---|
+| `false` (default) | `/algolia.json` | `/en/algolia.json` |
+| `true` | `/<defaultLang>/algolia.json` | `/en/algolia.json` |
+
+With `false`, the root `/algolia.json` is the default-language index. This is expected Hugo behavior, not a bug. In this documentation's sample config, `defaultContentLanguage: "ja"`, so with `true` the default-language output path becomes `/ja/algolia.json`.
+
+### Required config
+
+**`config/_default/outputFormats.yaml`**
+
+```yaml
+Algolia:
+  baseName: "algolia"
+  isPlainText: true
+  mediaType: "application/json"
+  notAlternative: true
+```
+
+**`config/_default/outputs.yaml`**
+
+```yaml
+home:
+  - "HTML"
+  - "Algolia"
+section:
+  - "HTML"
+```
+
+Generate only at `home`, not `section`, to avoid duplicate records.
+
+**`config/_default/params.yaml`**
+
+```yaml
+enableAlgolia: true
+
+algolia:
+  appId: "YOUR_APP_ID"
+  searchOnlyApiKey: "YOUR_SEARCH_ONLY_API_KEY"
+  indexName: "YOUR_INDEX_NAME"
+  vars:
+    - "title"
+    - "summary"
+    - "date"
+    - "permalink"
+  params:
+    - "tags"
+    - "categories"
+```
+
+### Per-language index names
+
+To use separate Algolia indexes per language, override `indexName` in the language block:
+
+```yaml
+languages:
+  ja:
+    params:
+      algolia:
+        indexName: YOUR_JA_INDEX
+  en:
+    params:
+      algolia:
+        indexName: YOUR_EN_INDEX
+```
+
+### Content organization by language
+
+When using many languages, organizing content by language directory is easier to
+maintain than filename suffixes.
+
+Add `contentDir` for each language in `languages` config:
+
+```yaml
+languages:
+  ja:
+    contentDir: content/ja
+  en:
+    contentDir: content/en
+```
+
+```text
+content/
+  ja/
+    posts/
+      tech/
+        article1.md
+    about.md
+  en/
+    posts/
+      tech/
+        article1.md
+    about.md
+```
+
+### Verifying the output
+
+```bash
+cd exampleSite && hugo --gc --minify
+
+# record counts (both should be non-zero)
+jq 'length' public/algolia.json
+jq 'length' public/en/algolia.json
+
+# confirm no cross-language contamination
+jq '[.[].permalink | contains("/en/")] | any' public/algolia.json   # expect false
+jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json  # expect true
+```

--- a/docs/guidance/getting-started.hi.md
+++ b/docs/guidance/getting-started.hi.md
@@ -1,4 +1,6 @@
-# Getting Started (Hindi)
+# Getting Started (हिन्दी)
+
+> Note: This locale-specific guide is currently an English placeholder. A full Hindi translation will be added in a follow-up update.
 
 This guide explains how to set up a new Hugo site with the HikaeMe theme.
 

--- a/docs/guidance/getting-started.hi.md
+++ b/docs/guidance/getting-started.hi.md
@@ -1,0 +1,258 @@
+# Getting Started (Hindi)
+
+This guide explains how to set up a new Hugo site with the HikaeMe theme.
+
+## Prerequisites
+
+Prepare the following tools:
+
+- [Hugo](https://gohugo.io/installation/)
+- [Go](https://golang.org/doc/install) (required for Hugo modules)
+- [Git](https://git-scm.com/)
+- [Node.js and npm](https://nodejs.org/)
+- GCC (required for compiling native dependencies)
+- Sass (SCSS compiler)
+
+For VS Code users (optional), sample dev container files are available here:
+
+- [devcontainer.json example](./assets/devcontainer.json)
+- [postCreateCommand.sh example](./assets/postCreateCommand.sh)
+
+Copy these files into a `.devcontainer/` directory (for example `.devcontainer/devcontainer.json` and `.devcontainer/postCreateCommand.sh`) so VS Code can detect and use them.
+Verify your environment:
+
+```bash
+hugo version
+go version
+git --version
+node --version
+npm --version
+gcc --version
+```
+
+## Setup Steps
+
+### Create a New Hugo Site
+
+```bash
+hugo new site my-blog --format yaml
+cd my-blog
+git init
+```
+
+### Initialize Your Site as a Hugo Module
+
+```bash
+hugo mod init github.com/yourusername/my-blog
+```
+
+This registers your site as a module. The module path does not need to match your final repository name, but it must be unique.
+
+### Add HikaeMe as a Module Dependency
+
+Add the module import to your site configuration. For a single-file setup, edit `hugo.yaml` and add:
+
+```yaml
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+```
+
+If you use a split configuration directory, place the same block in `config/_default/module.yaml`.
+
+### Download Theme Dependencies
+
+```bash
+hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod npm pack
+npm install
+```
+
+### Configuration Layout
+
+You can use either of these layouts:
+
+- Single-file config for small sites: `hugo.yaml`
+- Split config for larger sites: `config/_default/`
+
+This repository uses `config/_default/` to keep large settings manageable. A typical split layout looks like this:
+
+```text
+config/_default/
+  hugo.yaml
+  module.yaml
+  params.yaml
+  menus.yaml
+  outputs.yaml
+  outputFormats.yaml
+  permalinks.yaml
+```
+
+### Start the Development Server
+
+```bash
+hugo server -D
+```
+
+Open `http://localhost:1313` in your browser.
+
+## Minimal Configuration Example (`hugo.yaml`)
+
+```yaml
+title: "My Blog"
+baseURL: "https://example.com/"
+languageCode: "ja"
+
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+
+params:
+  author: "Your Name"
+  description: "My personal blog"
+```
+
+This guide uses a single `hugo.yaml` for brevity. If you prefer to split your configuration into multiple files, see [exampleSite/config/_default/](../../exampleSite/config/_default/) for a working example.
+
+## Multilingual Setup
+
+HikaeMe supports Hugo multilingual sites.
+
+- Recommended setup: single host with the default language at the root
+- Existing default-language URLs can remain canonical
+- Secondary languages can live under prefixes such as `/en/`
+- UI strings can be managed in `i18n/ja.yaml`, `i18n/en.yaml`, and other language files
+
+Example:
+
+```yaml
+defaultContentLanguage: "ja"
+defaultContentLanguageInSubdir: false
+
+languages:
+  ja:
+    languageCode: "ja-JP"
+    languageName: "Japanese"
+    weight: 1
+  en:
+    languageCode: "en-US"
+    languageName: "English"
+    weight: 2
+```
+
+Hugo will fall back to global configuration values for keys not defined inside a language block, which makes it practical to localize only the settings that differ.
+
+## Algolia Search with Multilingual Sites
+
+### Output path behavior
+
+Algolia JSON is generated at the **home** kind. Its output path depends on `defaultContentLanguageInSubdir`:
+
+| `defaultContentLanguageInSubdir` | Default language | Other languages |
+|---|---|---|
+| `false` (default) | `/algolia.json` | `/en/algolia.json` |
+| `true` | `/<defaultLang>/algolia.json` | `/en/algolia.json` |
+
+With `false`, the root `/algolia.json` is the default-language index. This is expected Hugo behavior, not a bug. In this documentation's sample config, `defaultContentLanguage: "ja"`, so with `true` the default-language output path becomes `/ja/algolia.json`.
+
+### Required config
+
+**`config/_default/outputFormats.yaml`**
+
+```yaml
+Algolia:
+  baseName: "algolia"
+  isPlainText: true
+  mediaType: "application/json"
+  notAlternative: true
+```
+
+**`config/_default/outputs.yaml`**
+
+```yaml
+home:
+  - "HTML"
+  - "Algolia"
+section:
+  - "HTML"
+```
+
+Generate only at `home`, not `section`, to avoid duplicate records.
+
+**`config/_default/params.yaml`**
+
+```yaml
+enableAlgolia: true
+
+algolia:
+  appId: "YOUR_APP_ID"
+  searchOnlyApiKey: "YOUR_SEARCH_ONLY_API_KEY"
+  indexName: "YOUR_INDEX_NAME"
+  vars:
+    - "title"
+    - "summary"
+    - "date"
+    - "permalink"
+  params:
+    - "tags"
+    - "categories"
+```
+
+### Per-language index names
+
+To use separate Algolia indexes per language, override `indexName` in the language block:
+
+```yaml
+languages:
+  ja:
+    params:
+      algolia:
+        indexName: YOUR_JA_INDEX
+  en:
+    params:
+      algolia:
+        indexName: YOUR_EN_INDEX
+```
+
+### Content organization by language
+
+When using many languages, organizing content by language directory is easier to
+maintain than filename suffixes.
+
+Add `contentDir` for each language in `languages` config:
+
+```yaml
+languages:
+  ja:
+    contentDir: content/ja
+  en:
+    contentDir: content/en
+```
+
+```text
+content/
+  ja/
+    posts/
+      tech/
+        article1.md
+    about.md
+  en/
+    posts/
+      tech/
+        article1.md
+    about.md
+```
+
+### Verifying the output
+
+```bash
+cd exampleSite && hugo --gc --minify
+
+# record counts (both should be non-zero)
+jq 'length' public/algolia.json
+jq 'length' public/en/algolia.json
+
+# confirm no cross-language contamination
+jq '[.[].permalink | contains("/en/")] | any' public/algolia.json   # expect false
+jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json  # expect true
+```

--- a/docs/guidance/getting-started.ko.md
+++ b/docs/guidance/getting-started.ko.md
@@ -1,0 +1,258 @@
+# Getting Started (Korean)
+
+This guide explains how to set up a new Hugo site with the HikaeMe theme.
+
+## Prerequisites
+
+Prepare the following tools:
+
+- [Hugo](https://gohugo.io/installation/)
+- [Go](https://golang.org/doc/install) (required for Hugo modules)
+- [Git](https://git-scm.com/)
+- [Node.js and npm](https://nodejs.org/)
+- GCC (required for compiling native dependencies)
+- Sass (SCSS compiler)
+
+For VS Code users (optional), sample dev container files are available here:
+
+- [devcontainer.json example](./assets/devcontainer.json)
+- [postCreateCommand.sh example](./assets/postCreateCommand.sh)
+
+Copy these files into a `.devcontainer/` directory (for example `.devcontainer/devcontainer.json` and `.devcontainer/postCreateCommand.sh`) so VS Code can detect and use them.
+Verify your environment:
+
+```bash
+hugo version
+go version
+git --version
+node --version
+npm --version
+gcc --version
+```
+
+## Setup Steps
+
+### Create a New Hugo Site
+
+```bash
+hugo new site my-blog --format yaml
+cd my-blog
+git init
+```
+
+### Initialize Your Site as a Hugo Module
+
+```bash
+hugo mod init github.com/yourusername/my-blog
+```
+
+This registers your site as a module. The module path does not need to match your final repository name, but it must be unique.
+
+### Add HikaeMe as a Module Dependency
+
+Add the module import to your site configuration. For a single-file setup, edit `hugo.yaml` and add:
+
+```yaml
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+```
+
+If you use a split configuration directory, place the same block in `config/_default/module.yaml`.
+
+### Download Theme Dependencies
+
+```bash
+hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod npm pack
+npm install
+```
+
+### Configuration Layout
+
+You can use either of these layouts:
+
+- Single-file config for small sites: `hugo.yaml`
+- Split config for larger sites: `config/_default/`
+
+This repository uses `config/_default/` to keep large settings manageable. A typical split layout looks like this:
+
+```text
+config/_default/
+  hugo.yaml
+  module.yaml
+  params.yaml
+  menus.yaml
+  outputs.yaml
+  outputFormats.yaml
+  permalinks.yaml
+```
+
+### Start the Development Server
+
+```bash
+hugo server -D
+```
+
+Open `http://localhost:1313` in your browser.
+
+## Minimal Configuration Example (`hugo.yaml`)
+
+```yaml
+title: "My Blog"
+baseURL: "https://example.com/"
+languageCode: "ja"
+
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+
+params:
+  author: "Your Name"
+  description: "My personal blog"
+```
+
+This guide uses a single `hugo.yaml` for brevity. If you prefer to split your configuration into multiple files, see [exampleSite/config/_default/](../../exampleSite/config/_default/) for a working example.
+
+## Multilingual Setup
+
+HikaeMe supports Hugo multilingual sites.
+
+- Recommended setup: single host with the default language at the root
+- Existing default-language URLs can remain canonical
+- Secondary languages can live under prefixes such as `/en/`
+- UI strings can be managed in `i18n/ja.yaml`, `i18n/en.yaml`, and other language files
+
+Example:
+
+```yaml
+defaultContentLanguage: "ja"
+defaultContentLanguageInSubdir: false
+
+languages:
+  ja:
+    languageCode: "ja-JP"
+    languageName: "Japanese"
+    weight: 1
+  en:
+    languageCode: "en-US"
+    languageName: "English"
+    weight: 2
+```
+
+Hugo will fall back to global configuration values for keys not defined inside a language block, which makes it practical to localize only the settings that differ.
+
+## Algolia Search with Multilingual Sites
+
+### Output path behavior
+
+Algolia JSON is generated at the **home** kind. Its output path depends on `defaultContentLanguageInSubdir`:
+
+| `defaultContentLanguageInSubdir` | Default language | Other languages |
+|---|---|---|
+| `false` (default) | `/algolia.json` | `/en/algolia.json` |
+| `true` | `/<defaultLang>/algolia.json` | `/en/algolia.json` |
+
+With `false`, the root `/algolia.json` is the default-language index. This is expected Hugo behavior, not a bug. In this documentation's sample config, `defaultContentLanguage: "ja"`, so with `true` the default-language output path becomes `/ja/algolia.json`.
+
+### Required config
+
+**`config/_default/outputFormats.yaml`**
+
+```yaml
+Algolia:
+  baseName: "algolia"
+  isPlainText: true
+  mediaType: "application/json"
+  notAlternative: true
+```
+
+**`config/_default/outputs.yaml`**
+
+```yaml
+home:
+  - "HTML"
+  - "Algolia"
+section:
+  - "HTML"
+```
+
+Generate only at `home`, not `section`, to avoid duplicate records.
+
+**`config/_default/params.yaml`**
+
+```yaml
+enableAlgolia: true
+
+algolia:
+  appId: "YOUR_APP_ID"
+  searchOnlyApiKey: "YOUR_SEARCH_ONLY_API_KEY"
+  indexName: "YOUR_INDEX_NAME"
+  vars:
+    - "title"
+    - "summary"
+    - "date"
+    - "permalink"
+  params:
+    - "tags"
+    - "categories"
+```
+
+### Per-language index names
+
+To use separate Algolia indexes per language, override `indexName` in the language block:
+
+```yaml
+languages:
+  ja:
+    params:
+      algolia:
+        indexName: YOUR_JA_INDEX
+  en:
+    params:
+      algolia:
+        indexName: YOUR_EN_INDEX
+```
+
+### Content organization by language
+
+When using many languages, organizing content by language directory is easier to
+maintain than filename suffixes.
+
+Add `contentDir` for each language in `languages` config:
+
+```yaml
+languages:
+  ja:
+    contentDir: content/ja
+  en:
+    contentDir: content/en
+```
+
+```text
+content/
+  ja/
+    posts/
+      tech/
+        article1.md
+    about.md
+  en/
+    posts/
+      tech/
+        article1.md
+    about.md
+```
+
+### Verifying the output
+
+```bash
+cd exampleSite && hugo --gc --minify
+
+# record counts (both should be non-zero)
+jq 'length' public/algolia.json
+jq 'length' public/en/algolia.json
+
+# confirm no cross-language contamination
+jq '[.[].permalink | contains("/en/")] | any' public/algolia.json   # expect false
+jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json  # expect true
+```

--- a/docs/guidance/getting-started.ko.md
+++ b/docs/guidance/getting-started.ko.md
@@ -1,4 +1,6 @@
-# Getting Started (Korean)
+# Getting Started (한국어)
+
+> Note: This locale-specific guide is currently an English placeholder. A full Korean translation will be added in a follow-up update.
 
 This guide explains how to set up a new Hugo site with the HikaeMe theme.
 

--- a/docs/guidance/getting-started.zh-cn.md
+++ b/docs/guidance/getting-started.zh-cn.md
@@ -1,4 +1,6 @@
-# Getting Started (Simplified Chinese)
+# Getting Started (简体中文)
+
+> Note: This locale-specific guide is currently an English placeholder. A full Simplified Chinese translation will be added in a follow-up update.
 
 This guide explains how to set up a new Hugo site with the HikaeMe theme.
 

--- a/docs/guidance/getting-started.zh-cn.md
+++ b/docs/guidance/getting-started.zh-cn.md
@@ -1,0 +1,258 @@
+# Getting Started (Simplified Chinese)
+
+This guide explains how to set up a new Hugo site with the HikaeMe theme.
+
+## Prerequisites
+
+Prepare the following tools:
+
+- [Hugo](https://gohugo.io/installation/)
+- [Go](https://golang.org/doc/install) (required for Hugo modules)
+- [Git](https://git-scm.com/)
+- [Node.js and npm](https://nodejs.org/)
+- GCC (required for compiling native dependencies)
+- Sass (SCSS compiler)
+
+For VS Code users (optional), sample dev container files are available here:
+
+- [devcontainer.json example](./assets/devcontainer.json)
+- [postCreateCommand.sh example](./assets/postCreateCommand.sh)
+
+Copy these files into a `.devcontainer/` directory (for example `.devcontainer/devcontainer.json` and `.devcontainer/postCreateCommand.sh`) so VS Code can detect and use them.
+Verify your environment:
+
+```bash
+hugo version
+go version
+git --version
+node --version
+npm --version
+gcc --version
+```
+
+## Setup Steps
+
+### Create a New Hugo Site
+
+```bash
+hugo new site my-blog --format yaml
+cd my-blog
+git init
+```
+
+### Initialize Your Site as a Hugo Module
+
+```bash
+hugo mod init github.com/yourusername/my-blog
+```
+
+This registers your site as a module. The module path does not need to match your final repository name, but it must be unique.
+
+### Add HikaeMe as a Module Dependency
+
+Add the module import to your site configuration. For a single-file setup, edit `hugo.yaml` and add:
+
+```yaml
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+```
+
+If you use a split configuration directory, place the same block in `config/_default/module.yaml`.
+
+### Download Theme Dependencies
+
+```bash
+hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod npm pack
+npm install
+```
+
+### Configuration Layout
+
+You can use either of these layouts:
+
+- Single-file config for small sites: `hugo.yaml`
+- Split config for larger sites: `config/_default/`
+
+This repository uses `config/_default/` to keep large settings manageable. A typical split layout looks like this:
+
+```text
+config/_default/
+  hugo.yaml
+  module.yaml
+  params.yaml
+  menus.yaml
+  outputs.yaml
+  outputFormats.yaml
+  permalinks.yaml
+```
+
+### Start the Development Server
+
+```bash
+hugo server -D
+```
+
+Open `http://localhost:1313` in your browser.
+
+## Minimal Configuration Example (`hugo.yaml`)
+
+```yaml
+title: "My Blog"
+baseURL: "https://example.com/"
+languageCode: "ja"
+
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+
+params:
+  author: "Your Name"
+  description: "My personal blog"
+```
+
+This guide uses a single `hugo.yaml` for brevity. If you prefer to split your configuration into multiple files, see [exampleSite/config/_default/](../../exampleSite/config/_default/) for a working example.
+
+## Multilingual Setup
+
+HikaeMe supports Hugo multilingual sites.
+
+- Recommended setup: single host with the default language at the root
+- Existing default-language URLs can remain canonical
+- Secondary languages can live under prefixes such as `/en/`
+- UI strings can be managed in `i18n/ja.yaml`, `i18n/en.yaml`, and other language files
+
+Example:
+
+```yaml
+defaultContentLanguage: "ja"
+defaultContentLanguageInSubdir: false
+
+languages:
+  ja:
+    languageCode: "ja-JP"
+    languageName: "Japanese"
+    weight: 1
+  en:
+    languageCode: "en-US"
+    languageName: "English"
+    weight: 2
+```
+
+Hugo will fall back to global configuration values for keys not defined inside a language block, which makes it practical to localize only the settings that differ.
+
+## Algolia Search with Multilingual Sites
+
+### Output path behavior
+
+Algolia JSON is generated at the **home** kind. Its output path depends on `defaultContentLanguageInSubdir`:
+
+| `defaultContentLanguageInSubdir` | Default language | Other languages |
+|---|---|---|
+| `false` (default) | `/algolia.json` | `/en/algolia.json` |
+| `true` | `/<defaultLang>/algolia.json` | `/en/algolia.json` |
+
+With `false`, the root `/algolia.json` is the default-language index. This is expected Hugo behavior, not a bug. In this documentation's sample config, `defaultContentLanguage: "ja"`, so with `true` the default-language output path becomes `/ja/algolia.json`.
+
+### Required config
+
+**`config/_default/outputFormats.yaml`**
+
+```yaml
+Algolia:
+  baseName: "algolia"
+  isPlainText: true
+  mediaType: "application/json"
+  notAlternative: true
+```
+
+**`config/_default/outputs.yaml`**
+
+```yaml
+home:
+  - "HTML"
+  - "Algolia"
+section:
+  - "HTML"
+```
+
+Generate only at `home`, not `section`, to avoid duplicate records.
+
+**`config/_default/params.yaml`**
+
+```yaml
+enableAlgolia: true
+
+algolia:
+  appId: "YOUR_APP_ID"
+  searchOnlyApiKey: "YOUR_SEARCH_ONLY_API_KEY"
+  indexName: "YOUR_INDEX_NAME"
+  vars:
+    - "title"
+    - "summary"
+    - "date"
+    - "permalink"
+  params:
+    - "tags"
+    - "categories"
+```
+
+### Per-language index names
+
+To use separate Algolia indexes per language, override `indexName` in the language block:
+
+```yaml
+languages:
+  ja:
+    params:
+      algolia:
+        indexName: YOUR_JA_INDEX
+  en:
+    params:
+      algolia:
+        indexName: YOUR_EN_INDEX
+```
+
+### Content organization by language
+
+When using many languages, organizing content by language directory is easier to
+maintain than filename suffixes.
+
+Add `contentDir` for each language in `languages` config:
+
+```yaml
+languages:
+  ja:
+    contentDir: content/ja
+  en:
+    contentDir: content/en
+```
+
+```text
+content/
+  ja/
+    posts/
+      tech/
+        article1.md
+    about.md
+  en/
+    posts/
+      tech/
+        article1.md
+    about.md
+```
+
+### Verifying the output
+
+```bash
+cd exampleSite && hugo --gc --minify
+
+# record counts (both should be non-zero)
+jq 'length' public/algolia.json
+jq 'length' public/en/algolia.json
+
+# confirm no cross-language contamination
+jq '[.[].permalink | contains("/en/")] | any' public/algolia.json   # expect false
+jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json  # expect true
+```

--- a/docs/guidance/getting-started.zh-tw.md
+++ b/docs/guidance/getting-started.zh-tw.md
@@ -1,0 +1,258 @@
+# Getting Started (Traditional Chinese)
+
+This guide explains how to set up a new Hugo site with the HikaeMe theme.
+
+## Prerequisites
+
+Prepare the following tools:
+
+- [Hugo](https://gohugo.io/installation/)
+- [Go](https://golang.org/doc/install) (required for Hugo modules)
+- [Git](https://git-scm.com/)
+- [Node.js and npm](https://nodejs.org/)
+- GCC (required for compiling native dependencies)
+- Sass (SCSS compiler)
+
+For VS Code users (optional), sample dev container files are available here:
+
+- [devcontainer.json example](./assets/devcontainer.json)
+- [postCreateCommand.sh example](./assets/postCreateCommand.sh)
+
+Copy these files into a `.devcontainer/` directory (for example `.devcontainer/devcontainer.json` and `.devcontainer/postCreateCommand.sh`) so VS Code can detect and use them.
+Verify your environment:
+
+```bash
+hugo version
+go version
+git --version
+node --version
+npm --version
+gcc --version
+```
+
+## Setup Steps
+
+### Create a New Hugo Site
+
+```bash
+hugo new site my-blog --format yaml
+cd my-blog
+git init
+```
+
+### Initialize Your Site as a Hugo Module
+
+```bash
+hugo mod init github.com/yourusername/my-blog
+```
+
+This registers your site as a module. The module path does not need to match your final repository name, but it must be unique.
+
+### Add HikaeMe as a Module Dependency
+
+Add the module import to your site configuration. For a single-file setup, edit `hugo.yaml` and add:
+
+```yaml
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+```
+
+If you use a split configuration directory, place the same block in `config/_default/module.yaml`.
+
+### Download Theme Dependencies
+
+```bash
+hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod npm pack
+npm install
+```
+
+### Configuration Layout
+
+You can use either of these layouts:
+
+- Single-file config for small sites: `hugo.yaml`
+- Split config for larger sites: `config/_default/`
+
+This repository uses `config/_default/` to keep large settings manageable. A typical split layout looks like this:
+
+```text
+config/_default/
+  hugo.yaml
+  module.yaml
+  params.yaml
+  menus.yaml
+  outputs.yaml
+  outputFormats.yaml
+  permalinks.yaml
+```
+
+### Start the Development Server
+
+```bash
+hugo server -D
+```
+
+Open `http://localhost:1313` in your browser.
+
+## Minimal Configuration Example (`hugo.yaml`)
+
+```yaml
+title: "My Blog"
+baseURL: "https://example.com/"
+languageCode: "ja"
+
+module:
+  imports:
+    - path: "github.com/htnabe/HikaeMe"
+
+params:
+  author: "Your Name"
+  description: "My personal blog"
+```
+
+This guide uses a single `hugo.yaml` for brevity. If you prefer to split your configuration into multiple files, see [exampleSite/config/_default/](../../exampleSite/config/_default/) for a working example.
+
+## Multilingual Setup
+
+HikaeMe supports Hugo multilingual sites.
+
+- Recommended setup: single host with the default language at the root
+- Existing default-language URLs can remain canonical
+- Secondary languages can live under prefixes such as `/en/`
+- UI strings can be managed in `i18n/ja.yaml`, `i18n/en.yaml`, and other language files
+
+Example:
+
+```yaml
+defaultContentLanguage: "ja"
+defaultContentLanguageInSubdir: false
+
+languages:
+  ja:
+    languageCode: "ja-JP"
+    languageName: "Japanese"
+    weight: 1
+  en:
+    languageCode: "en-US"
+    languageName: "English"
+    weight: 2
+```
+
+Hugo will fall back to global configuration values for keys not defined inside a language block, which makes it practical to localize only the settings that differ.
+
+## Algolia Search with Multilingual Sites
+
+### Output path behavior
+
+Algolia JSON is generated at the **home** kind. Its output path depends on `defaultContentLanguageInSubdir`:
+
+| `defaultContentLanguageInSubdir` | Default language | Other languages |
+|---|---|---|
+| `false` (default) | `/algolia.json` | `/en/algolia.json` |
+| `true` | `/<defaultLang>/algolia.json` | `/en/algolia.json` |
+
+With `false`, the root `/algolia.json` is the default-language index. This is expected Hugo behavior, not a bug. In this documentation's sample config, `defaultContentLanguage: "ja"`, so with `true` the default-language output path becomes `/ja/algolia.json`.
+
+### Required config
+
+**`config/_default/outputFormats.yaml`**
+
+```yaml
+Algolia:
+  baseName: "algolia"
+  isPlainText: true
+  mediaType: "application/json"
+  notAlternative: true
+```
+
+**`config/_default/outputs.yaml`**
+
+```yaml
+home:
+  - "HTML"
+  - "Algolia"
+section:
+  - "HTML"
+```
+
+Generate only at `home`, not `section`, to avoid duplicate records.
+
+**`config/_default/params.yaml`**
+
+```yaml
+enableAlgolia: true
+
+algolia:
+  appId: "YOUR_APP_ID"
+  searchOnlyApiKey: "YOUR_SEARCH_ONLY_API_KEY"
+  indexName: "YOUR_INDEX_NAME"
+  vars:
+    - "title"
+    - "summary"
+    - "date"
+    - "permalink"
+  params:
+    - "tags"
+    - "categories"
+```
+
+### Per-language index names
+
+To use separate Algolia indexes per language, override `indexName` in the language block:
+
+```yaml
+languages:
+  ja:
+    params:
+      algolia:
+        indexName: YOUR_JA_INDEX
+  en:
+    params:
+      algolia:
+        indexName: YOUR_EN_INDEX
+```
+
+### Content organization by language
+
+When using many languages, organizing content by language directory is easier to
+maintain than filename suffixes.
+
+Add `contentDir` for each language in `languages` config:
+
+```yaml
+languages:
+  ja:
+    contentDir: content/ja
+  en:
+    contentDir: content/en
+```
+
+```text
+content/
+  ja/
+    posts/
+      tech/
+        article1.md
+    about.md
+  en/
+    posts/
+      tech/
+        article1.md
+    about.md
+```
+
+### Verifying the output
+
+```bash
+cd exampleSite && hugo --gc --minify
+
+# record counts (both should be non-zero)
+jq 'length' public/algolia.json
+jq 'length' public/en/algolia.json
+
+# confirm no cross-language contamination
+jq '[.[].permalink | contains("/en/")] | any' public/algolia.json   # expect false
+jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json  # expect true
+```

--- a/docs/guidance/getting-started.zh-tw.md
+++ b/docs/guidance/getting-started.zh-tw.md
@@ -1,4 +1,6 @@
-# Getting Started (Traditional Chinese)
+# Getting Started (繁體中文)
+
+> Note: This locale-specific guide is currently an English placeholder. A full Traditional Chinese translation will be added in a follow-up update.
 
 This guide explains how to set up a new Hugo site with the HikaeMe theme.
 


### PR DESCRIPTION
## Overview
Add per-language getting-started guidance files so every currently supported locale has a dedicated guide file under docs/guidance.

## Changes
- Added getting-started guidance files for: de, es, fr, hi, ko, zh-cn, zh-tw.
- Used the existing English guide as the baseline content for consistency.
- Set language-specific headings in each new file.

## Related Issues
None.

## Checklist
- [x] Self-review done (following review.prompt.md)
- [ ] Hugo production build passes: cd exampleSite && hugo --gc --minify
- [x] Docs updated if behavior changed
- [x] No unrelated changes included

## Notes for Reviewers
This PR focuses on file coverage so each supported language has a guidance document path. Content translation quality can be improved in follow-up PRs if needed.
