### PR TITLE
Fix/replace language code locale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     env:
-      HUGO_VERSION: 0.157.0
+      HUGO_VERSION: 0.160.0
       DART_SASS_VERSION: 1.97.3
       HUSKY: 0
 
@@ -152,7 +152,7 @@ jobs:
 
       - name: Install Hugo and Dart Sass
         env:
-          HUGO_VERSION: 0.157.0
+          HUGO_VERSION: 0.160.0
           DART_SASS_VERSION: 1.97.3
         run: |
           mkdir -p "${HOME}/.local"

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -11,6 +11,10 @@
 @use "./_variables" as v;
 @use "sass:map";
 
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   font-family:
     /* macOS / iOS */

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -7,7 +7,7 @@ enableEmoji: true
 enableGitInfo: true
 enableRobotsTXT: true
 timeZone:
-languageCode:
+locale:
 headers:
   - for: "/*" # Apply to all pages
     values:

--- a/config/_default/module.yaml
+++ b/config/_default/module.yaml
@@ -1,3 +1,3 @@
 hugoVersion:
   extended: true
-  min: "0.144.0"
+  min: "0.160.0"

--- a/docs/guidance/getting-started.en.md
+++ b/docs/guidance/getting-started.en.md
@@ -6,7 +6,7 @@ This guide explains how to set up a new Hugo site with the HikaeMe theme.
 
 Prepare the following tools:
 
-- [Hugo](https://gohugo.io/installation/)
+- [Hugo](https://gohugo.io/installation/) (0.160.0 or newer)
 - [Go](https://golang.org/doc/install) (required for Hugo modules)
 - [Git](https://git-scm.com/)
 - [Node.js and npm](https://nodejs.org/)
@@ -101,7 +101,7 @@ Open `http://localhost:1313` in your browser.
 ```yaml
 title: "My Blog"
 baseURL: "https://example.com/"
-languageCode: "ja"
+locale: "ja-JP"
 
 module:
   imports:
@@ -131,12 +131,12 @@ defaultContentLanguageInSubdir: false
 
 languages:
   ja:
-    languageCode: "ja-JP"
-    languageName: "Japanese"
+    locale: "ja-JP"
+    label: "Japanese"
     weight: 1
   en:
-    languageCode: "en-US"
-    languageName: "English"
+    locale: "en-US"
+    label: "English"
     weight: 2
 ```
 

--- a/docs/guidance/getting-started.ja.md
+++ b/docs/guidance/getting-started.ja.md
@@ -6,7 +6,7 @@
 
 以下のツールを事前に用意してください。
 
-- [Hugo](https://gohugo.io/installation/)
+- [Hugo](https://gohugo.io/installation/)（0.160.0 以上）
 - [Go](https://golang.org/doc/install)（Hugo Modules に必要）
 - [Git](https://git-scm.com/)
 - [Node.js と npm](https://nodejs.org/)
@@ -101,7 +101,7 @@ hugo server -D
 ```yaml
 title: "My Blog"
 baseURL: "https://example.com/"
-languageCode: "ja"
+locale: "ja-JP"
 
 module:
   imports:
@@ -131,12 +131,12 @@ defaultContentLanguageInSubdir: false
 
 languages:
   ja:
-    languageCode: "ja-JP"
-    languageName: "日本語"
+    locale: "ja-JP"
+    label: "日本語"
     weight: 1
   en:
-    languageCode: "en-US"
-    languageName: "English"
+    locale: "en-US"
+    label: "English"
     weight: 2
 ```
 

--- a/exampleSite/config/_default/hugo.yaml
+++ b/exampleSite/config/_default/hugo.yaml
@@ -7,4 +7,4 @@ enableEmoji: true
 enableGitInfo: true
 enableRobotsTXT: true
 timeZone: "Japan"
-languageCode: "ja-JP"
+locale: "ja-JP"

--- a/exampleSite/config/_default/languages.yaml
+++ b/exampleSite/config/_default/languages.yaml
@@ -1,6 +1,6 @@
 ja:
-  languageCode: "ja-JP"
-  languageName: "日本語"
+  locale: "ja-JP"
+  label: "日本語"
   contentDir: "content/ja"
   weight: 1
   params:
@@ -13,8 +13,8 @@ ja:
         - year: "20zz"
           title: "Webエンジニアとして勤務"
 en:
-  languageCode: "en-US"
-  languageName: "English"
+  locale: "en-US"
+  label: "English"
   contentDir: "content/en"
   weight: 2
   params:
@@ -27,8 +27,8 @@ en:
         - year: "20zz"
           title: "Worked as a web engineer"
 zh-cn:
-  languageCode: "zh-CN"
-  languageName: "简体中文"
+  locale: "zh-CN"
+  label: "简体中文"
   contentDir: "content/zh-cn"
   weight: 3
   params:
@@ -41,8 +41,8 @@ zh-cn:
         - year: "20zz"
           title: "担任 Web 工程师"
 zh-tw:
-  languageCode: "zh-TW"
-  languageName: "繁體中文"
+  locale: "zh-TW"
+  label: "繁體中文"
   contentDir: "content/zh-tw"
   weight: 4
   params:
@@ -55,8 +55,8 @@ zh-tw:
         - year: "20zz"
           title: "擔任 Web 工程師"
 ko:
-  languageCode: "ko-KR"
-  languageName: "한국어"
+  locale: "ko-KR"
+  label: "한국어"
   contentDir: "content/ko"
   weight: 5
   params:
@@ -69,8 +69,8 @@ ko:
         - year: "20zz"
           title: "웹 엔지니어로 근무"
 de:
-  languageCode: "de-DE"
-  languageName: "Deutsch"
+  locale: "de-DE"
+  label: "Deutsch"
   contentDir: "content/de"
   weight: 6
   params:
@@ -83,8 +83,8 @@ de:
         - year: "20zz"
           title: "Als Webentwickler gearbeitet"
 fr:
-  languageCode: "fr-FR"
-  languageName: "Français"
+  locale: "fr-FR"
+  label: "Français"
   contentDir: "content/fr"
   weight: 7
   params:
@@ -97,8 +97,8 @@ fr:
         - year: "20zz"
           title: "Travail en tant qu'ingénieur web"
 hi:
-  languageCode: "hi-IN"
-  languageName: "हिन्दी"
+  locale: "hi-IN"
+  label: "हिन्दी"
   contentDir: "content/hi"
   weight: 8
   params:
@@ -111,8 +111,8 @@ hi:
         - year: "20zz"
           title: "वेब इंजीनियर के रूप में काम किया"
 es:
-  languageCode: "es-ES"
-  languageName: "Español"
+  locale: "es-ES"
+  label: "Español"
   contentDir: "content/es"
   weight: 9
   params:

--- a/exampleSite/package-lock.json
+++ b/exampleSite/package-lock.json
@@ -4,119 +4,120 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "exampleSite",
       "workspaces": [
         "packages/hugoautogen"
       ]
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.20.0.tgz",
-      "integrity": "sha512-5CqkS592H3+24b6H6CQ2RVpphdmAuIElZzv0Hngqo/ZEZpUZJ+KGLcueBhx33fv2wYBXyuuvskG5aQ7Ti+lR0g==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.0.tgz",
+      "integrity": "sha512-kGvHfBa9oQCvZh0YXeguSToBD9GNJ+gzUZQ9KPTg+KSsM36obYcsKPoX0NnlJtPflHXu7RkMaIi44xs9meR6Zw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.54.0.tgz",
-      "integrity": "sha512-IXnH1x3DBsPQA4/FRO0Pvkfy79tKy5Qr+ugAV9jdcGkpzHc476D0WV1MFJ+pZxtbts0xh2JqzUVmYEqA6LkOpA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.0.tgz",
+      "integrity": "sha512-Zt2GjIm7vsaf7K23tk5JmtcVNc38G9p0C2L2Lrm06miyLE/NL2etHtHInvuLc1DjxTp7Y2nId4X/tzwo372K8Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.54.0.tgz",
-      "integrity": "sha512-pBpRqm1wpE0GnGy2rNLk9rjDn0Le4iywNRtnAWblLeqfjxpWKg8lWnk7nmSoTShFO31sz2jatXXzxK2lz8ipbA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.0.tgz",
+      "integrity": "sha512-7BueMuWYg/KBA2EX9zsQ+3OAleEyrJcB+SV5Al/9pLjMQq5mXB/8M5HaUPqZwN812g5kLzj9j43VThlZgWq0hg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.54.0.tgz",
-      "integrity": "sha512-WbuwRUlFvSOsuxqTDjSSmgusuF5KFt+oFPzobvPDvodra6EWnVwUXjz0elkNSsnsIlZGtcXlX3LhxkO7rF90jw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.0.tgz",
+      "integrity": "sha512-pJZIyhvUrs+B7c5Lw0iP5yP/NsqJMda7pKRYbfG4KtfGIVSMcAalZhdqL5UX8Z9DOC4KxO9tKV5RDeVjZU0VfQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.54.0.tgz",
-      "integrity": "sha512-/HNLVi3kPI+JhO59WbglLjPM2c4uECU+x4gk1iADseKtE5eYqJ/RJ+FIwM8xzPFKhFJaw+8hVq4lkd0nn8HDDg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.0.tgz",
+      "integrity": "sha512-RydkKDhx0GWTYuw0ndTXHGM8hD8hgwftKE65FfnJZb5bPc9CevOqv3qNPUQiviAwkqT9hQNH31uDGeV3yZkgfA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.54.0.tgz",
-      "integrity": "sha512-6TolyyDRumIKeLGBGSFAZsSIJ8hrm6NFCGR1jO7pQTiOtSWgAIxcFE5/JRpZ3g+unG4OkNOFy+I0dUEquIDbig==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.0.tgz",
+      "integrity": "sha512-XiS7gdFq/COWiwdWXZ8+RHuewfEo03TkGESk44zU8zTc/Z6R8fm4DNmV52swJKkeB2N9iC7NKpgpM22OOkcgTw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.54.0.tgz",
-      "integrity": "sha512-AxW2MLBhjBtGX5kIZrVLO2SP2vRkZxJw5qHGxnQJfLcYhA04mFNP0fWRtHshlcVnDk9M8L9lwfr2lGpf3Er+hw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.0.tgz",
+      "integrity": "sha512-LBEJ/q+hn1nJ0aYg5IcWgLNCPjWHTahWmpHNx1qUZMho+9CyWM6LaEnhac45UHjQm/j0m374HP685VrpL133lA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.54.0.tgz",
-      "integrity": "sha512-ngdgVGp05lJzUyA+sUzr0MDZ7AMtANcJpwIzq4ZsfpZL5B3S7A4XYfMcU2sECZc3bx3ysOhYcdbbaTjc3ve0WQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.0.tgz",
+      "integrity": "sha512-2/9jUXKH4IcdU5qxH6cbDH46ZBe46G7xr+MrcHwgEXZcUfdAvUgLSH53MAWuMgxvw0G5yoqiWMifHc62Os0fiQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -129,81 +130,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.54.0.tgz",
-      "integrity": "sha512-hee59Z7FgZ6/13FYL05ANPwRJY1pfvIlrwC8eBZYdiRFXTJVvf94IyTWOxLqRVpbseDP6eQQTW+PT7/DxTZIng==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.0.tgz",
+      "integrity": "sha512-80tKsQgxXWo+jK0v4YGCHqyTEXawhAKYyr3kOdN51ElfRqUFjZNPVhZk6vRiqSqXfvrH85ytacT3cbJR6+qolA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.54.0.tgz",
-      "integrity": "sha512-diCjZVbIO7Pzw98tEKqLWIAgmQBI3Zt1sHsXyAPNGZgn32derpIXTnjjpJbZl+uAhSSznd6SfxFGdC9uYdN1TA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.0.tgz",
+      "integrity": "sha512-4UjmAL8ywGW4rCfK6Qmgw3wIjbrO2wl2s4Eq56JTiN40L2t0XTv0HZkYAmr6nfeiXO0he/2crvZRX6SATSepag==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.54.0.tgz",
-      "integrity": "sha512-6zeslypRAGWDgVJEJYAPuqmyquHvnw4MQwG+XXdrw5dTNDjXYIcCJdQQcCY06xPF9tUvmzy/1vHiH9QxhgwuOQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.0.tgz",
+      "integrity": "sha512-LMpJPtIkfDsHIx5Ga+baNr22ntYbY+e2wT7MSIc/FjAnu9wnBFhx1H/GfhmP/c5/IvbThDX+3ilxPRjSfCI8aA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.54.0.tgz",
-      "integrity": "sha512-iHZax214LPXd7XizQ4BNnTsegl8f3IeKm8JcrmSNZ/5x1rZ5xLkbG/anltAWtLpoRNnfpr4Z80YdYeVVPpx6wQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.0.tgz",
+      "integrity": "sha512-tDymJ7nFOAoUuecma3usK6o94dp8m4HYFDGh4ByYQXWkv14cpmDn+nWdylmcZO0Qvco107vqDo4+Anksnl8w1Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.54.0.tgz",
-      "integrity": "sha512-YKtuG5YwPxZ+kkfd4HmUO7Z9aICPUSMlHslzKTmtMMhxGnetxEqGj9T/v2r/PdcuOUC5oW0CHe8akJk8cpS3gQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.0.tgz",
+      "integrity": "sha512-6IDSB5o5dkDPQ4LdOW0Yuw/qy5MdWlO2xDHgPVZgW4YDjbxvnX5PAiV7/WWZdWyVObScZZnnHpPbiqfYs/zBLg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.54.0.tgz",
-      "integrity": "sha512-zyZDJ4WS5TnjZZ5pqywTBFO9olW7QMtY2kf2dbLnu+UTzfc9ri/HGf27jRN2NTbX9FcRPxSqPqzUhF/BZIx0VA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.0.tgz",
+      "integrity": "sha512-Yyyne4l//vDSdg4MhYJkaVne+KEPi833eCj3/T/87ernTwrvP6j9biXXZELsN8sLI/f2ndV/vugDIy2jdJQB6g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -553,13 +554,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -947,16 +948,16 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -965,13 +966,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -992,9 +993,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1005,13 +1006,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1019,14 +1020,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1035,9 +1036,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1045,13 +1046,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1066,25 +1067,25 @@
       "license": "ISC"
     },
     "node_modules/algoliasearch": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.54.0.tgz",
-      "integrity": "sha512-APAX4ajIOgsmYoUlGe++oNZkSTBgmXYM4maHC0OxC+Yo7xkaKQElV0ATZYCZA7jzrSJX1OBiqEs7mk+ZxXgYqA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.0.tgz",
+      "integrity": "sha512-af+rI+tUVeS9KWHPAZQHIHPOIC3StPRR6IwQu2nz1aQoTL6Gs5Ty3KsHCgbXMHOpoh9QqSjq8F3KJ8xmaCZSBA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.20.0",
-        "@algolia/client-abtesting": "5.54.0",
-        "@algolia/client-analytics": "5.54.0",
-        "@algolia/client-common": "5.54.0",
-        "@algolia/client-insights": "5.54.0",
-        "@algolia/client-personalization": "5.54.0",
-        "@algolia/client-query-suggestions": "5.54.0",
-        "@algolia/client-search": "5.54.0",
-        "@algolia/ingestion": "1.54.0",
-        "@algolia/monitoring": "1.54.0",
-        "@algolia/recommend": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/abtesting": "1.21.0",
+        "@algolia/client-abtesting": "5.55.0",
+        "@algolia/client-analytics": "5.55.0",
+        "@algolia/client-common": "5.55.0",
+        "@algolia/client-insights": "5.55.0",
+        "@algolia/client-personalization": "5.55.0",
+        "@algolia/client-query-suggestions": "5.55.0",
+        "@algolia/client-search": "5.55.0",
+        "@algolia/ingestion": "1.55.0",
+        "@algolia/monitoring": "1.55.0",
+        "@algolia/recommend": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -2047,9 +2048,9 @@
       }
     },
     "node_modules/instantsearch-ui-components": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.30.1.tgz",
-      "integrity": "sha512-0bwxs9bKTusS0EIr2wmyltcLDkeIU5gHc6W0PDjp8VJrmBCB7ULa2qPIxpumO7B8ifp2pNoJtwpqXLup7/60DQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.31.0.tgz",
+      "integrity": "sha512-mdbxlzsCQKs4IygXEibO29LrA8uFtToBKQyHUHeQiHvPWOdZWxhBZ1ZE1C6GjmKnOBZWDnVAn/rwhNKTYhCFKw==",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "0.5.18",
@@ -2057,9 +2058,9 @@
       }
     },
     "node_modules/instantsearch.js": {
-      "version": "4.101.1",
-      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.101.1.tgz",
-      "integrity": "sha512-cSbjGQ85mSNLghcRfcryVl5tOYsNLCbmQC9g1mTJR+gFzunvirxDuQIaMdOw3Uy6RQmFt9ri8i3TVq9xLIkpzw==",
+      "version": "4.102.0",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.102.0.tgz",
+      "integrity": "sha512-Ury18PgLVyQ7NFlWLJI/DvPGaM+tMW+AntjsEADA/2ZJ1MS+iX/END2ojLcHSWfp2oeHWAs6fG8x/hbcgm2g5Q==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1",
@@ -2071,7 +2072,7 @@
         "algoliasearch-helper": "3.29.1",
         "hogan.js": "^3.0.2",
         "htm": "^3.0.0",
-        "instantsearch-ui-components": "0.30.1",
+        "instantsearch-ui-components": "0.31.0",
         "preact": "^10.10.0",
         "qs": "^6.5.1",
         "react": ">= 0.14.0",
@@ -2887,13 +2888,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2906,9 +2907,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3678,9 +3679,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3829,19 +3830,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -3869,12 +3870,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4125,15 +4126,15 @@
       "name": "exampleSite",
       "version": "0.1.0",
       "dependencies": {
-        "@algolia/client-search": "^5.53.0",
+        "@algolia/client-search": "^5.55.0",
         "@popperjs/core": "^2.11.8",
-        "algoliasearch": "^5.53.0",
+        "algoliasearch": "^5.55.0",
         "bootstrap": "^5.3.8",
-        "instantsearch.js": "^4.101.0"
+        "instantsearch.js": "^4.102.0"
       },
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "^8.0.0",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "^1.61.0",
         "@types/bootstrap": "^5.2.11",
         "autoprefixer": "^10.5.0",
         "husky": "^9.1.7",
@@ -4142,9 +4143,9 @@
         "npm-check-updates": "^22.2.3",
         "postcss": "^8.5.15",
         "postcss-cli": "^11.0.1",
-        "prettier": "^3.8.3",
+        "prettier": "^3.8.4",
         "prettier-plugin-go-template": "^0.0.15",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.9"
       }
     }
   }

--- a/exampleSite/packages/hugoautogen/hugo_packagemeta.json
+++ b/exampleSite/packages/hugoautogen/hugo_packagemeta.json
@@ -1,5 +1,5 @@
 {
-  "sum": "32f2a76aaf1b931c",
+  "sum": "3fbc584a26c23634",
   "dependencySources": {
     "dependencies": {
       "@algolia/client-search": "../../../HikaeMe",

--- a/exampleSite/packages/hugoautogen/package.json
+++ b/exampleSite/packages/hugoautogen/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "@algolia/client-search": "^5.53.0",
+    "@algolia/client-search": "^5.55.0",
     "@popperjs/core": "^2.11.8",
-    "algoliasearch": "^5.53.0",
+    "algoliasearch": "^5.55.0",
     "bootstrap": "^5.3.8",
-    "instantsearch.js": "^4.101.0"
+    "instantsearch.js": "^4.102.0"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^8.0.0",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.0",
     "@types/bootstrap": "^5.2.11",
     "autoprefixer": "^10.5.0",
     "husky": "^9.1.7",
@@ -17,9 +17,9 @@
     "npm-check-updates": "^22.2.3",
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "prettier-plugin-go-template": "^0.0.15",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.9"
   },
   "name": "exampleSite",
   "version": "0.1.0"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -22,7 +22,10 @@
 {{- "-->" | safeHTML -}}
 
 
-<html lang="{{ .Site.Language.LanguageCode }}" data-bs-theme="auto">
+<html
+  lang="{{ .Site.Language.Locale | default .Site.Language.Lang }}"
+  data-bs-theme="auto"
+>
   <head>
     {{ partial "head.html" . }}
     {{ if templates.Exists "partials/custom-head.html" }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -99,7 +99,9 @@
       "searchReadMore" (T "search.readMore"))
     }}
 
-    {{ $compiledJs := resources.Get "ts/algolia.ts" | js.Build $tsCommonOpt | resources.Minify }}
+    {{ $langTargetPath := printf "ts/algolia.%s.js" $.Lang }}
+    {{ $tsLangOpt := merge $tsCommonOpt (dict "targetPath" $langTargetPath) }}
+    {{ $compiledJs := resources.Get "ts/algolia.ts" | js.Build $tsLangOpt | resources.Minify }}
     <script
       defer
       type="text/javascript"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -87,7 +87,7 @@
                 >
                   <span class="fs-6 m-0 fw-semibold">
                     <i class="bi bi-translate"></i>
-                    {{ .Site.Language.LanguageName }}
+                    {{ .Site.Language.Label | default .Site.Language.Lang }}
                   </span>
                 </button>
                 <ul
@@ -109,12 +109,12 @@
                           active
                         {{ end }}"
                         href="{{ $targetURL }}"
-                        hreflang="{{ $langHome.Language.LanguageCode | default $langHome.Language.Lang }}"
-                        lang="{{ $langHome.Language.LanguageCode | default $langHome.Language.Lang }}"
+                        hreflang="{{ $langHome.Language.Locale | default $langHome.Language.Lang }}"
+                        lang="{{ $langHome.Language.Locale | default $langHome.Language.Lang }}"
                         data-testid="language-option-{{ $langHome.Language.Lang }}"
                       >
                         <span>
-                          {{ $langHome.Language.LanguageName | default (upper $langHome.Language.Lang) }}
+                          {{ $langHome.Language.Label | default (upper $langHome.Language.Lang) }}
                         </span>
                       </a>
                     </li>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -61,7 +61,7 @@
 <meta name="description" content="{{ .Scratch.Get $description }}" />
 
 {{/* Open Graph Protocol */}}
-{{ $ogLocale := replace (.Site.Language.LanguageCode | default .Site.Language.Lang) "-" "_" }}
+{{ $ogLocale := replace (.Site.Language.Locale | default .Site.Language.Lang) "-" "_" }}
 <meta property="og:locale" content="{{ $ogLocale }}" />
 <meta property="og:title" content="{{ .Scratch.Get $title }}" />
 <meta property="og:url" content="{{ .Permalink }}" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,18 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "HikaeMe",
       "version": "1.4.0",
       "dependencies": {
-        "@algolia/client-search": "^5.53.0",
+        "@algolia/client-search": "^5.55.0",
         "@popperjs/core": "^2.11.8",
-        "algoliasearch": "^5.54.0",
+        "algoliasearch": "^5.55.0",
         "bootstrap": "^5.3.8",
-        "instantsearch.js": "^4.101.1"
+        "instantsearch.js": "^4.102.0"
       },
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "^8.0.0",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "^1.61.0",
         "@types/bootstrap": "^5.2.11",
         "autoprefixer": "^10.5.0",
         "husky": "^9.1.7",
@@ -26,121 +27,121 @@
         "postcss-cli": "^11.0.1",
         "prettier": "^3.8.4",
         "prettier-plugin-go-template": "^0.0.15",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=22.22.1"
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.20.0.tgz",
-      "integrity": "sha512-5CqkS592H3+24b6H6CQ2RVpphdmAuIElZzv0Hngqo/ZEZpUZJ+KGLcueBhx33fv2wYBXyuuvskG5aQ7Ti+lR0g==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.0.tgz",
+      "integrity": "sha512-kGvHfBa9oQCvZh0YXeguSToBD9GNJ+gzUZQ9KPTg+KSsM36obYcsKPoX0NnlJtPflHXu7RkMaIi44xs9meR6Zw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.54.0.tgz",
-      "integrity": "sha512-IXnH1x3DBsPQA4/FRO0Pvkfy79tKy5Qr+ugAV9jdcGkpzHc476D0WV1MFJ+pZxtbts0xh2JqzUVmYEqA6LkOpA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.0.tgz",
+      "integrity": "sha512-Zt2GjIm7vsaf7K23tk5JmtcVNc38G9p0C2L2Lrm06miyLE/NL2etHtHInvuLc1DjxTp7Y2nId4X/tzwo372K8Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.54.0.tgz",
-      "integrity": "sha512-pBpRqm1wpE0GnGy2rNLk9rjDn0Le4iywNRtnAWblLeqfjxpWKg8lWnk7nmSoTShFO31sz2jatXXzxK2lz8ipbA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.0.tgz",
+      "integrity": "sha512-7BueMuWYg/KBA2EX9zsQ+3OAleEyrJcB+SV5Al/9pLjMQq5mXB/8M5HaUPqZwN812g5kLzj9j43VThlZgWq0hg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.54.0.tgz",
-      "integrity": "sha512-WbuwRUlFvSOsuxqTDjSSmgusuF5KFt+oFPzobvPDvodra6EWnVwUXjz0elkNSsnsIlZGtcXlX3LhxkO7rF90jw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.0.tgz",
+      "integrity": "sha512-pJZIyhvUrs+B7c5Lw0iP5yP/NsqJMda7pKRYbfG4KtfGIVSMcAalZhdqL5UX8Z9DOC4KxO9tKV5RDeVjZU0VfQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.54.0.tgz",
-      "integrity": "sha512-/HNLVi3kPI+JhO59WbglLjPM2c4uECU+x4gk1iADseKtE5eYqJ/RJ+FIwM8xzPFKhFJaw+8hVq4lkd0nn8HDDg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.0.tgz",
+      "integrity": "sha512-RydkKDhx0GWTYuw0ndTXHGM8hD8hgwftKE65FfnJZb5bPc9CevOqv3qNPUQiviAwkqT9hQNH31uDGeV3yZkgfA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.54.0.tgz",
-      "integrity": "sha512-6TolyyDRumIKeLGBGSFAZsSIJ8hrm6NFCGR1jO7pQTiOtSWgAIxcFE5/JRpZ3g+unG4OkNOFy+I0dUEquIDbig==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.0.tgz",
+      "integrity": "sha512-XiS7gdFq/COWiwdWXZ8+RHuewfEo03TkGESk44zU8zTc/Z6R8fm4DNmV52swJKkeB2N9iC7NKpgpM22OOkcgTw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.54.0.tgz",
-      "integrity": "sha512-AxW2MLBhjBtGX5kIZrVLO2SP2vRkZxJw5qHGxnQJfLcYhA04mFNP0fWRtHshlcVnDk9M8L9lwfr2lGpf3Er+hw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.0.tgz",
+      "integrity": "sha512-LBEJ/q+hn1nJ0aYg5IcWgLNCPjWHTahWmpHNx1qUZMho+9CyWM6LaEnhac45UHjQm/j0m374HP685VrpL133lA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.54.0.tgz",
-      "integrity": "sha512-ngdgVGp05lJzUyA+sUzr0MDZ7AMtANcJpwIzq4ZsfpZL5B3S7A4XYfMcU2sECZc3bx3ysOhYcdbbaTjc3ve0WQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.0.tgz",
+      "integrity": "sha512-2/9jUXKH4IcdU5qxH6cbDH46ZBe46G7xr+MrcHwgEXZcUfdAvUgLSH53MAWuMgxvw0G5yoqiWMifHc62Os0fiQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -153,81 +154,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.54.0.tgz",
-      "integrity": "sha512-hee59Z7FgZ6/13FYL05ANPwRJY1pfvIlrwC8eBZYdiRFXTJVvf94IyTWOxLqRVpbseDP6eQQTW+PT7/DxTZIng==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.0.tgz",
+      "integrity": "sha512-80tKsQgxXWo+jK0v4YGCHqyTEXawhAKYyr3kOdN51ElfRqUFjZNPVhZk6vRiqSqXfvrH85ytacT3cbJR6+qolA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.54.0.tgz",
-      "integrity": "sha512-diCjZVbIO7Pzw98tEKqLWIAgmQBI3Zt1sHsXyAPNGZgn32derpIXTnjjpJbZl+uAhSSznd6SfxFGdC9uYdN1TA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.0.tgz",
+      "integrity": "sha512-4UjmAL8ywGW4rCfK6Qmgw3wIjbrO2wl2s4Eq56JTiN40L2t0XTv0HZkYAmr6nfeiXO0he/2crvZRX6SATSepag==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.54.0.tgz",
-      "integrity": "sha512-6zeslypRAGWDgVJEJYAPuqmyquHvnw4MQwG+XXdrw5dTNDjXYIcCJdQQcCY06xPF9tUvmzy/1vHiH9QxhgwuOQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.0.tgz",
+      "integrity": "sha512-LMpJPtIkfDsHIx5Ga+baNr22ntYbY+e2wT7MSIc/FjAnu9wnBFhx1H/GfhmP/c5/IvbThDX+3ilxPRjSfCI8aA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.54.0.tgz",
-      "integrity": "sha512-iHZax214LPXd7XizQ4BNnTsegl8f3IeKm8JcrmSNZ/5x1rZ5xLkbG/anltAWtLpoRNnfpr4Z80YdYeVVPpx6wQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.0.tgz",
+      "integrity": "sha512-tDymJ7nFOAoUuecma3usK6o94dp8m4HYFDGh4ByYQXWkv14cpmDn+nWdylmcZO0Qvco107vqDo4+Anksnl8w1Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.54.0.tgz",
-      "integrity": "sha512-YKtuG5YwPxZ+kkfd4HmUO7Z9aICPUSMlHslzKTmtMMhxGnetxEqGj9T/v2r/PdcuOUC5oW0CHe8akJk8cpS3gQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.0.tgz",
+      "integrity": "sha512-6IDSB5o5dkDPQ4LdOW0Yuw/qy5MdWlO2xDHgPVZgW4YDjbxvnX5PAiV7/WWZdWyVObScZZnnHpPbiqfYs/zBLg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.54.0.tgz",
-      "integrity": "sha512-zyZDJ4WS5TnjZZ5pqywTBFO9olW7QMtY2kf2dbLnu+UTzfc9ri/HGf27jRN2NTbX9FcRPxSqPqzUhF/BZIx0VA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.0.tgz",
+      "integrity": "sha512-Yyyne4l//vDSdg4MhYJkaVne+KEPi833eCj3/T/87ernTwrvP6j9biXXZELsN8sLI/f2ndV/vugDIy2jdJQB6g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.54.0"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -510,14 +511,14 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -577,13 +578,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -971,16 +972,16 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -989,13 +990,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1016,9 +1017,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1029,13 +1030,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1043,14 +1044,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1059,9 +1060,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1069,13 +1070,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1090,25 +1091,25 @@
       "license": "ISC"
     },
     "node_modules/algoliasearch": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.54.0.tgz",
-      "integrity": "sha512-APAX4ajIOgsmYoUlGe++oNZkSTBgmXYM4maHC0OxC+Yo7xkaKQElV0ATZYCZA7jzrSJX1OBiqEs7mk+ZxXgYqA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.0.tgz",
+      "integrity": "sha512-af+rI+tUVeS9KWHPAZQHIHPOIC3StPRR6IwQu2nz1aQoTL6Gs5Ty3KsHCgbXMHOpoh9QqSjq8F3KJ8xmaCZSBA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.20.0",
-        "@algolia/client-abtesting": "5.54.0",
-        "@algolia/client-analytics": "5.54.0",
-        "@algolia/client-common": "5.54.0",
-        "@algolia/client-insights": "5.54.0",
-        "@algolia/client-personalization": "5.54.0",
-        "@algolia/client-query-suggestions": "5.54.0",
-        "@algolia/client-search": "5.54.0",
-        "@algolia/ingestion": "1.54.0",
-        "@algolia/monitoring": "1.54.0",
-        "@algolia/recommend": "5.54.0",
-        "@algolia/requester-browser-xhr": "5.54.0",
-        "@algolia/requester-fetch": "5.54.0",
-        "@algolia/requester-node-http": "5.54.0"
+        "@algolia/abtesting": "1.21.0",
+        "@algolia/client-abtesting": "5.55.0",
+        "@algolia/client-analytics": "5.55.0",
+        "@algolia/client-common": "5.55.0",
+        "@algolia/client-insights": "5.55.0",
+        "@algolia/client-personalization": "5.55.0",
+        "@algolia/client-query-suggestions": "5.55.0",
+        "@algolia/client-search": "5.55.0",
+        "@algolia/ingestion": "1.55.0",
+        "@algolia/monitoring": "1.55.0",
+        "@algolia/recommend": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -2074,9 +2075,9 @@
       }
     },
     "node_modules/instantsearch-ui-components": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.30.1.tgz",
-      "integrity": "sha512-0bwxs9bKTusS0EIr2wmyltcLDkeIU5gHc6W0PDjp8VJrmBCB7ULa2qPIxpumO7B8ifp2pNoJtwpqXLup7/60DQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.31.0.tgz",
+      "integrity": "sha512-mdbxlzsCQKs4IygXEibO29LrA8uFtToBKQyHUHeQiHvPWOdZWxhBZ1ZE1C6GjmKnOBZWDnVAn/rwhNKTYhCFKw==",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "0.5.18",
@@ -2084,9 +2085,9 @@
       }
     },
     "node_modules/instantsearch.js": {
-      "version": "4.101.1",
-      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.101.1.tgz",
-      "integrity": "sha512-cSbjGQ85mSNLghcRfcryVl5tOYsNLCbmQC9g1mTJR+gFzunvirxDuQIaMdOw3Uy6RQmFt9ri8i3TVq9xLIkpzw==",
+      "version": "4.102.0",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.102.0.tgz",
+      "integrity": "sha512-Ury18PgLVyQ7NFlWLJI/DvPGaM+tMW+AntjsEADA/2ZJ1MS+iX/END2ojLcHSWfp2oeHWAs6fG8x/hbcgm2g5Q==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1",
@@ -2098,7 +2099,7 @@
         "algoliasearch-helper": "3.29.1",
         "hogan.js": "^3.0.2",
         "htm": "^3.0.0",
-        "instantsearch-ui-components": "0.30.1",
+        "instantsearch-ui-components": "0.31.0",
         "preact": "^10.10.0",
         "qs": "^6.5.1",
         "react": ">= 0.14.0",
@@ -2904,13 +2905,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2923,9 +2924,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3160,9 +3161,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -3695,9 +3696,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3846,19 +3847,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -3886,12 +3887,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
     }
   },
   "dependencies": {
-    "@algolia/client-search": "^5.53.0",
+    "@algolia/client-search": "^5.55.0",
     "@popperjs/core": "^2.11.8",
-    "algoliasearch": "^5.54.0",
+    "algoliasearch": "^5.55.0",
     "bootstrap": "^5.3.8",
-    "instantsearch.js": "^4.101.1"
+    "instantsearch.js": "^4.102.0"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^8.0.0",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.0",
     "@types/bootstrap": "^5.2.11",
     "autoprefixer": "^10.5.0",
     "husky": "^9.1.7",
@@ -33,7 +33,7 @@
     "postcss-cli": "^11.0.1",
     "prettier": "^3.8.4",
     "prettier-plugin-go-template": "^0.0.15",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.9"
   },
   "lint-staged": {
     "*.{html,css,scss}": "prettier --write",

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -117,6 +117,36 @@ test.describe("Navigation", () => {
   test.describe("Mobile navigation", () => {
     test.use({ viewport: { width: 390, height: 844 } });
 
+    test("drawer shows backdrop and closes via button and backdrop tap", async ({
+      page,
+    }) => {
+      await page.goto("/");
+
+      const drawerToggle = page.locator("button.navbar-toggler");
+      const drawer = page.locator("#navbarOffcanvas");
+
+      await expect(drawerToggle).toBeVisible();
+      await drawerToggle.click();
+      await expect(drawer).toHaveClass(/show/);
+
+      let backdrop = page.locator(".offcanvas-backdrop");
+      await expect(backdrop).toBeVisible();
+
+      await drawer.locator("button.btn-close").click();
+      await expect(drawer).not.toHaveClass(/show/);
+      await expect(page.locator(".offcanvas-backdrop")).toHaveCount(0);
+
+      await drawerToggle.click();
+      await expect(drawer).toHaveClass(/show/);
+
+      backdrop = page.locator(".offcanvas-backdrop");
+      await expect(backdrop).toBeVisible();
+      await backdrop.click();
+
+      await expect(drawer).not.toHaveClass(/show/);
+      await expect(page.locator(".offcanvas-backdrop")).toHaveCount(0);
+    });
+
     test("search from open drawer prioritizes modal or closes drawer", async ({
       page,
     }) => {


### PR DESCRIPTION
## Overview
This PR prepares the theme for the next release by combining Hugo language API migration work with search UI localization fixes and related validation improvements.

## Changes
- Migrated deprecated Hugo language config/template usage:
  - languageCode -> locale
  - languageName -> label
  - .Site.Language.LanguageCode / .Language.LanguageName -> .Locale / .Label with fallbacks
- Raised required Hugo version to 0.160.0 and aligned CI Hugo version to 0.160.0.
- Updated getting-started docs (EN/JA) to reflect new language keys and Hugo minimum version.
- Added mobile e2e coverage for offcanvas drawer backdrop visibility and close behavior.
- Fixed search modal localization leakage by generating locale-specific Algolia bundles (for example: /ts/algolia.en.min.js, /ts/algolia.es.min.js).
- Updated dependency manifests/lockfiles (Algolia ecosystem + related tooling) and regenerated hugoautogen metadata.
- Related Issues: N/A

## Checklist
 - [x] Self-review done (following review.prompt.md)
 - [x] Hugo production build passes: cd exampleSite && hugo --gc --minify
 - [x] Docs updated if behavior changed
- [x]  No unrelated changes included

## Notes for Reviewers
This branch contains multiple focused commits (deps, Hugo migration/docs, e2e, search fix, style tweak) to keep review traceable.
Existing Bootstrap Sass deprecation warnings are upstream and unchanged by this PR.