### PR TITLE
chore(release): prepare v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "HikaeMe",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "HikaeMe",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "dependencies": {
         "@algolia/client-search": "^5.55.0",
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
     "test:e2e": "playwright test",
     "update": "ncu -u && npm install --ignore-scripts"
   },
-  "version": "1.4.0"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
## Overview

Prepare the v2.0.0 release by bumping package version metadata and creating the release tag commit.
This follows the repository release workflow and targets `dev` for merge.

## Changes

- Bump `package.json` version from `1.4.0` to `2.0.0`
- Bump `package-lock.json` version from `1.4.0` to `2.0.0`
- Include release commit/tag generated by `npm version`:
  - Commit: `chore(release): v2.0.0`
  - Tag: `v2.0.0`

## Related Issues

- N/A

## Checklist

- [x] Self-review done (following `review.prompt.md`)
- [x] Hugo production build passes: `cd exampleSite && hugo --gc --minify`
- [ ] Docs updated if behavior changed
- [x] No unrelated changes included

## Notes for Reviewers

- This PR is intentionally scoped to release metadata/tag preparation only.
- Breaking changes for this major release are already included in previous `dev` commits (e.g. `languageCode` to `locale`, Hugo minimum version 0.160.0, and Bootstrap delivery updates).
