### PR TITLE
chore(release): v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Note: Guidance documents are currently available in English and Japanese.
 - Project Structure: [docs/develop/project-structure.md](./docs/develop/project-structure.md)
 - Testing Policy: [docs/develop/testing-policy.md](./docs/develop/testing-policy.md)
 
+### Versioning
+
+This repository uses Go module semantic import versioning.
+
+- v1.x.x releases use `github.com/htnabe/HikaeMe`
+- v2.x.x and later releases use `github.com/htnabe/HikaeMe/v2`
+
+Even for stable versions v1.x.x and above, not all patches have been applied, and we are gradually marking them as deprecated.
+The [Release Page](https://github.com/htnabe/HikaeMe/releases) lists the deprecated versions, so please check it as needed.
+
 ## Demo
 
 - [My personal blog](https://t-pot.me/)

--- a/docs/guidance/getting-started.en.md
+++ b/docs/guidance/getting-started.en.md
@@ -30,6 +30,19 @@ npm --version
 gcc --version
 ```
 
+## Versioning
+
+HikaeMe follows Go module semantic import versioning:
+
+- Use `github.com/htnabe/HikaeMe` for v1.x.x releases
+- Use `github.com/htnabe/HikaeMe/v2` for v2.x.x and later releases
+
+For v2 and later, the repository root `go.mod` must declare:
+
+```go
+module github.com/htnabe/HikaeMe/v2
+```
+
 ## Setup Steps
 
 ### Create a New Hugo Site
@@ -55,15 +68,16 @@ Add the module import to your site configuration. For a single-file setup, edit 
 ```yaml
 module:
   imports:
-    - path: "github.com/htnabe/HikaeMe"
+    - path: "github.com/htnabe/HikaeMe/v2"
 ```
 
 If you use a split configuration directory, place the same block in `config/_default/module.yaml`.
+If you are staying on v1.x.x, use `github.com/htnabe/HikaeMe` instead.
 
 ### Download Theme Dependencies
 
 ```bash
-hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod get -u github.com/htnabe/HikaeMe/v2
 hugo mod npm pack
 npm install
 ```
@@ -105,7 +119,7 @@ locale: "ja-JP"
 
 module:
   imports:
-    - path: "github.com/htnabe/HikaeMe"
+    - path: "github.com/htnabe/HikaeMe/v2"
 
 params:
   author: "Your Name"

--- a/docs/guidance/getting-started.ja.md
+++ b/docs/guidance/getting-started.ja.md
@@ -30,6 +30,19 @@ npm --version
 gcc --version
 ```
 
+## バージョニング
+
+HikaeMe は Go module のセマンティックインポートバージョニングに従います。
+
+- v1.x.x では `github.com/htnabe/HikaeMe` を使います
+- v2.x.x 以降では `github.com/htnabe/HikaeMe/v2` を使います
+
+v2 以降では、リポジトリ直下の `go.mod` に次の宣言が必要です。
+
+```go
+module github.com/htnabe/HikaeMe/v2
+```
+
 ## セットアップ手順
 
 ### Hugo サイトを新規作成
@@ -55,15 +68,16 @@ hugo mod init github.com/yourusername/my-blog
 ```yaml
 module:
   imports:
-    - path: "github.com/htnabe/HikaeMe"
+    - path: "github.com/htnabe/HikaeMe/v2"
 ```
 
 設定を分割している場合は、同じ内容を `config/_default/module.yaml` に配置してください。
+v1.x.x を使う場合は、代わりに `github.com/htnabe/HikaeMe` を指定してください。
 
 ### 依存関係を取得
 
 ```bash
-hugo mod get -u github.com/htnabe/HikaeMe
+hugo mod get -u github.com/htnabe/HikaeMe/v2
 hugo mod npm pack
 npm install
 ```
@@ -105,7 +119,7 @@ locale: "ja-JP"
 
 module:
   imports:
-    - path: "github.com/htnabe/HikaeMe"
+    - path: "github.com/htnabe/HikaeMe/v2"
 
 params:
   author: "Your Name"

--- a/docs/guidance/troubleshooting.md
+++ b/docs/guidance/troubleshooting.md
@@ -6,6 +6,8 @@ This page collects common setup and development issues for HikaeMe.
 
 Solution:
 1. Ensure your site configuration has the correct module import path.
+	- v1.x.x: `github.com/htnabe/HikaeMe`
+	- v2.x.x and later: `github.com/htnabe/HikaeMe/v2`
 2. If you use split config files, check `config/_default/module.yaml` instead of a single `hugo.yaml`.
 3. Try clearing the cache:
 

--- a/exampleSite/config/_default/module.yaml
+++ b/exampleSite/config/_default/module.yaml
@@ -1,5 +1,5 @@
 imports:
-  - path: github.com/htnabe/HikaeMe
+  - path: github.com/htnabe/HikaeMe/v2
 
 replacements:
-  - github.com/htnabe/HikaeMe -> ../../../HikaeMe
+  - github.com/htnabe/HikaeMe/v2 -> ../../../HikaeMe

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/htnabe/HikaeMe
+module github.com/htnabe/HikaeMe/v2
 
 go 1.18

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "HikaeMe",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "HikaeMe",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@algolia/client-search": "^5.55.0",
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
     "test:e2e": "playwright test",
     "update": "ncu -u && npm install --ignore-scripts"
   },
-  "version": "2.0.0"
+  "version": "2.0.1"
 }


### PR DESCRIPTION
## Overview

Release v2.0.1.

## Changes

- Bump package version to 2.0.1 and create tag v2.0.1.
- Update v2 module path guidance in the README and getting-started docs.
- Keep the example site module import aligned with the new v2 path.

## Related Issues

None.

## Checklist

- [x] Self-review done (following `review.prompt.md`)
- [x] Hugo production build passes: `cd exampleSite && hugo --gc --minify`
- [x] Docs updated if behavior changed
- [x] No unrelated changes included

## Notes for Reviewers

The branch includes the versioning guidance update needed for v2.x.x releases.
