### PR TITLE
docs: update issue templates and guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,19 +6,22 @@ labels: "bug"
 assignees: ""
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behavior, including relevant config snippets or content examples.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### To Reproduce
+<!-- Steps to reproduce the behavior, including relevant config snippets or content examples. -->
 
-**Environment**
+## Environment
 
+<!--
 - Hugo version: [e.g. 0.157.0]
 - OS / Browser: [e.g. macOS, Chrome 120]
+ -->
 
-**Additional context**
-Screenshots, logs, or any other context.
+## Additional context
+
+<!-- Screenshots, logs, or any other context. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,14 +6,14 @@ labels: "enhancement"
 assignees: ""
 ---
 
-**Problem / Goal**
-What problem does this solve, or what goal does it support?
+## Problem / Goal
+<!-- What problem does this solve, or what goal does it support? -->
 
-**Proposed solution**
-A clear and concise description of what you want to happen.
+### Proposed solution
+<!-- A clear and concise description of what you want to happen. -->
 
-**Alternatives considered**
-Any alternative approaches you've thought about.
+### Alternatives considered
+<!-- Any alternative approaches you've thought about. -->
 
-**Additional context**
-Screenshots, links, or any other relevant context.
+## Additional context
+<!-- Screenshots, links, or any other relevant context. -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,6 +31,7 @@ These instructions define how AI coding assistants should work in this repositor
 - Reuse existing partials under `layouts/partials/` instead of duplicating markup.
 - Keep theme behavior configurable via site params where applicable.
 - Avoid hard-coded environment-specific values.
+- For `js.Build` options, pass typed values (e.g. `"minify"` must be `true`/`false` as a bool, not a string). Hugo currently weak-casts string booleans, but do not rely on that behavior.
 
 ## Frontend Asset Guidelines
 


### PR DESCRIPTION
## Overview

Update GitHub issue templates for clearer structure and add Hugo `js.Build` guidance for typed option values.

## Changes

- Convert bug report and feature request prompts to Markdown headings with helper text in comments.
- Add guidance to avoid string booleans in Hugo `js.Build` options.

## Related Issues

None.

## Checklist

- [x] Self-review done (following `review.prompt.md`)
- [x] Hugo production build passes: `cd exampleSite && hugo --gc --minify`
- [x] Docs updated if behavior changed
- [x] No unrelated changes included

## Notes for Reviewers

`hugo --gc --minify` passed with existing npm sync and Bootstrap/Dart Sass deprecation warnings.