### PR TITLE
feat: add cloudinary auto transform with global toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A simple theme that displays only the bare minimum of elements readers need.
 - [Cloudinary 画像 (JA)](./docs/guidance/cloudinary-images.ja.md)
 - [Troubleshooting](./docs/guidance/troubleshooting.md)
 
-Note: Guidance documents are currently available in English and Japanese.
+> [!NOTE]
+> Guidance documents are currently available in English and Japanese.
 
 ### Develop (for contributors/developers/AI)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A simple theme that displays only the bare minimum of elements readers need.
 
 - [English](./docs/guidance/getting-started.en.md)
 - [日本語](./docs/guidance/getting-started.ja.md)
+- [Image Accessibility (EN)](./docs/guidance/image-accessibility.en.md)
+- [画像アクセシビリティ (JA)](./docs/guidance/image-accessibility.ja.md)
+- [Cloudinary Images (EN)](./docs/guidance/cloudinary-images.en.md)
+- [Cloudinary 画像 (JA)](./docs/guidance/cloudinary-images.ja.md)
 - [Troubleshooting](./docs/guidance/troubleshooting.md)
 
 Note: Guidance documents are currently available in English and Japanese.

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -11,6 +11,8 @@ logoImageUrl: # https://~ format is also supported
 copyright:
 contactUrl: # Optional, if you want to add a contact form / sns account please write the URL here
 enableAlgolia: true
+useCloudinary: false
+cloudinaryCloudName: # Optional, required when useCloudinary=true and using Cloudinary URL transforms
 logoFontFamily:
 favicon:
   defaultUrl: # Required, add a url to the 32x32 size image. eg: "img/icon.webp"

--- a/docs/guidance/cloudinary-images.en.md
+++ b/docs/guidance/cloudinary-images.en.md
@@ -1,0 +1,66 @@
+# Cloudinary Images Guide
+
+This page explains how to enable Cloudinary image URL transformation in HikaeMe.
+
+## Quick Summary
+
+- Toggle feature: params.useCloudinary
+- Cloud name: params.cloudinaryCloudName
+- If useCloudinary is false, all image paths are used as normal (no transformation).
+
+## Configuration
+
+Add the following to your params configuration:
+
+```yaml
+useCloudinary: true
+cloudinaryCloudName: "your-cloud-name"
+```
+
+## How It Works
+
+When useCloudinary is true, HikaeMe checks image URLs.
+
+- Cloudinary base URLs in non-transformed format are automatically transformed with f_auto and q_auto.
+- Non-Cloudinary URLs stay unchanged.
+
+This behavior is applied to:
+
+- Markdown images rendered by render-image
+- Home/list thumbnails
+- Article thumbnails
+- Open Graph and Twitter card images
+- Author thumbnail
+- img shortcode source URL
+
+## cldimg Shortcode
+
+Use cldimg when you want explicit responsive srcset generation.
+
+```markdown
+{{< cldimg
+  url="https://res.cloudinary.com/your-cloud-name/image/upload/v1234/path/to/image.webp"
+  alt="Example image"
+  caption="Optional caption"
+>}}
+```
+
+Optional parameters:
+
+- class
+- sizes
+- loading
+- crop
+- caption
+
+## Validation Rules
+
+With useCloudinary=true, cldimg validates that:
+
+- URL starts with your configured cloud name prefix.
+- URL is in /image/upload/v... format.
+- URL does not already include transformations before version.
+
+## Fallback Behavior
+
+If useCloudinary=false, cldimg renders a regular img tag with the provided URL and no transformation.

--- a/docs/guidance/cloudinary-images.en.md
+++ b/docs/guidance/cloudinary-images.en.md
@@ -8,6 +8,14 @@ This page explains how to enable Cloudinary image URL transformation in HikaeMe.
 - Cloud name: params.cloudinaryCloudName
 - If useCloudinary is false, all image paths are used as normal (no transformation).
 
+> [!IMPORTANT]
+> If your site uses Cloudinary images as the primary source, prefer the cldimg shortcode directly.
+> The img shortcode still works with Cloudinary URLs, but it does not generate responsive srcset/sizes.
+> Use cldimg when you want image and bandwidth optimization across device widths.
+
+> [!NOTE]
+> If your site does not use Cloudinary images, set useCloudinary: false and use the img shortcode.
+
 ## Configuration
 
 Add the following to your params configuration:
@@ -53,6 +61,10 @@ Optional parameters:
 - crop
 - caption
 
+> [!NOTE]
+> cldimg and img do not produce the same output with useCloudinary=true.
+> img renders a single src URL, while cldimg renders src plus responsive srcset and sizes.
+
 ## Validation Rules
 
 With useCloudinary=true, cldimg validates that:
@@ -60,6 +72,10 @@ With useCloudinary=true, cldimg validates that:
 - URL starts with your configured cloud name prefix.
 - URL is in /image/upload/v... format.
 - URL does not already include transformations before version.
+
+> [!CAUTION]
+> For cldimg, pass a non-transformed base Cloudinary URL.
+> If the URL already includes transformations before the version segment, cldimg fails validation by design.
 
 ## Fallback Behavior
 

--- a/docs/guidance/cloudinary-images.ja.md
+++ b/docs/guidance/cloudinary-images.ja.md
@@ -1,0 +1,66 @@
+# Cloudinary 画像ガイド
+
+このページでは、HikaeMeでCloudinary画像URL変換を有効化する方法を説明します。
+
+## 要点
+
+- 切り替えフラグ: params.useCloudinary
+- Cloud名: params.cloudinaryCloudName
+- useCloudinaryがfalseの場合、全画像を通常URLのまま使います（変換なし）。
+
+## 設定
+
+params設定に次を追加します。
+
+```yaml
+useCloudinary: true
+cloudinaryCloudName: "your-cloud-name"
+```
+
+## 動作
+
+useCloudinary=true のとき、HikaeMeは画像URLを判定します。
+
+- Cloudinaryの非変換URLは f_auto と q_auto を付与して自動変換
+- Cloudinary以外のURLはそのまま使用
+
+この挙動は次に適用されます。
+
+- Markdown画像（render-image）
+- ホーム/一覧サムネイル
+- 記事サムネイル
+- OGP/Twitterカード画像
+- 著者サムネイル
+- img shortcode のsrc
+
+## cldimg Shortcode
+
+cldimg は、明示的にレスポンシブsrcsetを出したい場合に使います。
+
+```markdown
+{{< cldimg
+  url="https://res.cloudinary.com/your-cloud-name/image/upload/v1234/path/to/image.webp"
+  alt="画像の説明"
+  caption="任意のキャプション"
+>}}
+```
+
+任意パラメータ:
+
+- class
+- sizes
+- loading
+- crop
+- caption
+
+## 検証ルール
+
+useCloudinary=true の場合、cldimg は次を検証します。
+
+- URLが設定したcloud nameのprefixで始まること
+- URLが /image/upload/v... 形式であること
+- バージョン前に変換オプションが入っていないこと
+
+## フォールバック
+
+useCloudinary=false の場合、cldimg は変換せず、指定URLで通常のimgタグを出力します。

--- a/docs/guidance/cloudinary-images.ja.md
+++ b/docs/guidance/cloudinary-images.ja.md
@@ -8,6 +8,14 @@
 - Cloud名: params.cloudinaryCloudName
 - useCloudinaryがfalseの場合、全画像を通常URLのまま使います（変換なし）。
 
+> [!IMPORTANT]
+> サイトで Cloudinary 画像を主に使う場合は、cldimg shortcode を優先してください。
+> img shortcode でも Cloudinary URL は動作しますが、レスポンシブな srcset/sizes は生成されません。
+> 端末幅ごとの画像・帯域最適化を行いたい場合は cldimg を使ってください。
+
+> [!NOTE]
+> Cloudinary 画像を使わないサイトでは useCloudinary: false とし、img shortcode を使ってください。
+
 ## 設定
 
 params設定に次を追加します。
@@ -53,6 +61,10 @@ cldimg は、明示的にレスポンシブsrcsetを出したい場合に使い�
 - crop
 - caption
 
+> [!NOTE]
+> useCloudinary=true の場合でも、cldimg と img は同じ出力になりません。
+> img は単一の src を出力し、cldimg は src に加えて srcset と sizes を出力します。
+
 ## 検証ルール
 
 useCloudinary=true の場合、cldimg は次を検証します。
@@ -60,6 +72,10 @@ useCloudinary=true の場合、cldimg は次を検証します。
 - URLが設定したcloud nameのprefixで始まること
 - URLが /image/upload/v... 形式であること
 - バージョン前に変換オプションが入っていないこと
+
+> [!CAUTION]
+> cldimg には、変換オプションを含まない Cloudinary ベースURLを渡してください。
+> バージョンセグメントより前に変換オプションが入っているURLは、仕様上バリデーションエラーになります。
 
 ## フォールバック
 

--- a/docs/guidance/getting-started.en.md
+++ b/docs/guidance/getting-started.en.md
@@ -307,3 +307,4 @@ jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json  # expect 
 ## Additional Guidance
 
 - [Image Accessibility Guide](./image-accessibility.en.md)
+- [Cloudinary Images Guide](./cloudinary-images.en.md)

--- a/docs/guidance/getting-started.ja.md
+++ b/docs/guidance/getting-started.ja.md
@@ -307,3 +307,4 @@ jq '[.[].permalink | contains("/en/")] | all'  public/en/algolia.json # true で
 ## 追加ガイダンス
 
 - [画像アクセシビリティガイド](./image-accessibility.ja.md)
+- [Cloudinary 画像ガイド](./cloudinary-images.ja.md)

--- a/docs/guidance/image-accessibility.en.md
+++ b/docs/guidance/image-accessibility.en.md
@@ -10,7 +10,8 @@ This page describes the image accessibility policy for HikaeMe.
 
 ## Current Enforcement Level
 
-The current enforcement level is warning-based.
+> [!IMPORTANT]
+> The current enforcement level is warning-based.
 
 - Markdown images always render an alt attribute (empty alt="" is allowed for decorative images).
 - The img shortcode emits a warning when neither alt nor caption is provided.
@@ -46,4 +47,5 @@ Fallback (legacy compatible, warning-free):
 
 ## Future Direction
 
-This policy may be tightened from warnings to build errors in a future release after migration guidance is complete.
+> [!CAUTION]
+> This policy may be tightened from warnings to build errors in a future release after migration guidance is complete.

--- a/docs/guidance/image-accessibility.ja.md
+++ b/docs/guidance/image-accessibility.ja.md
@@ -10,7 +10,8 @@
 
 ## alt に対する警告表示レベル
 
-現在は警告ベースで適用しています。
+> [!IMPORTANT]
+> 現在は警告ベースで適用しています。
 
 - Markdown 画像は alt 属性を常時出力します（装飾画像は alt="" を許容します）。
 - img shortcode で alt が未指定かつ caption も未指定の場合、warning を出します。
@@ -46,4 +47,5 @@
 
 ## 今後の方針
 
-移行ガイドの整備後、将来的に warning から build error へ厳格化する可能性があります。
+> [!CAUTION]
+> 移行ガイドの整備後、将来的に warning から build error へ厳格化する可能性があります。

--- a/exampleSite/config/_default/params.yaml
+++ b/exampleSite/config/_default/params.yaml
@@ -5,13 +5,13 @@ googlefonts: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500
 enableHighlight: true
 amazonAssociateId: "" # Optional, Include amazon affiliate ID(eg. hikaeme-22)
 since: "2020" # you can add the start period
-defaultThumbnailUrl: "/img/about-page-thumbnail.webp" # https://~ format is also supported
+defaultThumbnailUrl: "https://res.cloudinary.com/takenoko/image/upload/v1632659294/NabeBlog/aboutPage-Thumbnail_lphxof.webp" # https://~ format is also supported
 logoImageUrl: "/img/site-logo.webp" # https://~ format is also supported
 copyright: "author name?"
 contactUrl: "" # Optional, if you want to add a contact form / sns accFount please write the URL here
 enableAlgolia: true
-useCloudinary: false
-cloudinaryCloudName: ""
+useCloudinary: true
+cloudinaryCloudName: "takenoko"
 logoFontFamily: "Orbitron"
 favicon:
   defaultUrl: "/img/icon.webp" # Required, add a url to the 32x32 size image. eg: "/img/icon.webp"

--- a/exampleSite/config/_default/params.yaml
+++ b/exampleSite/config/_default/params.yaml
@@ -10,6 +10,8 @@ logoImageUrl: "/img/site-logo.webp" # https://~ format is also supported
 copyright: "author name?"
 contactUrl: "" # Optional, if you want to add a contact form / sns accFount please write the URL here
 enableAlgolia: true
+useCloudinary: false
+cloudinaryCloudName: ""
 logoFontFamily: "Orbitron"
 favicon:
   defaultUrl: "/img/icon.webp" # Required, add a url to the 32x32 size image. eg: "/img/icon.webp"

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,6 +1,13 @@
 {{- $alt := .PlainText | default "" -}}
+{{- $resolvedImageURL := partial "image-url.html" (dict
+  "site" .Page.Site
+  "url" .Destination
+  "keepRelative" true
+  "width" (.Page.Params.cloudinaryImageWidth | default 1200)
+  )
+-}}
 <img
-  src="{{- .Destination | safeURL -}}"
+  src="{{- $resolvedImageURL | safeURL -}}"
   loading="lazy"
   alt="{{ $alt }}"
   {{- with .Title }}title="{{ . }}"{{ end -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -3,7 +3,7 @@
   "site" .Page.Site
   "url" .Destination
   "keepRelative" true
-  "width" (.Page.Params.cloudinaryImageWidth | default 1200)
+  "width" 1200
   )
 -}}
 <img
@@ -16,9 +16,7 @@
       .Page.Resources.GetMatch .Destination
     -}}
       {{- if eq .MediaType.SubType "svg" -}}
-        {{/* SVGファイルの場合はXMLとしてパースしてheight,
-          width属性を設定
-        */}}
+        {{/* For SVG files, parse as XML and set height/width attributes. */}}
         {{- with .Content | transform.Unmarshal -}}
           {{- with index . "-width" -}}width="{{ . }}"{{ end -}}
           {{- with index . "-height" -}}height="{{ . }}"{{ end -}}
@@ -31,7 +29,7 @@
       {{- if and (not
         (hasPrefix $path "/" )) (not (hasPrefix $path "../" ))
       -}}
-        {{/* ファイルが存在しない場合はエラー */}}
+        {{/* Raise an error when the file does not exist. */}}
         {{- errorf "Not Found Image: %s in page %s" .Destination .Page.Path -}}
       {{- end -}}
     {{- end -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -16,13 +16,15 @@
   {{ $paginator := .Paginate (where $pctx.RegularPages ".Type" "posts") }}
 
   {{ range $index, $page := $paginator.Pages }}
+    {{- $thumbnail := $page.Params.thumbnail | default .Site.Params.defaultThumbnailUrl -}}
+    {{- $thumbnailURL := partial "image-url.html" (dict "site" .Site "url" $thumbnail "width" 640) -}}
     <article class="li article-hover">
       <a class="text-decoration-none" href="{{ .RelPermalink }}">
         <div class="card mb-3 border-0 bg-body">
           <div class="row g-0">
             <img
               class="col-md-4 thumb-sm-height rounded object-fit-cover"
-              src="{{ ($page.Params.thumbnail | default .Site.Params.defaultThumbnailUrl) | absURL }}"
+              src="{{ $thumbnailURL }}"
               alt="article thumbnail"
               {{ if ge $index 4 }}loading="lazy"{{ end }}
               {{ if le $index 3 }}fetchpriority="high"{{ end }}

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,10 +1,12 @@
 <article class="card-wrapper mb-4 mt-4 p-0">
   <div class="card border-0">
     {{ $showThumb := .Page.Params.show_thumb_post | default true }}
+    {{- $thumbnail := .Page.Params.thumbnail | default .Site.Params.defaultThumbnailUrl -}}
+    {{- $thumbnailURL := partial "image-url.html" (dict "site" .Site "url" $thumbnail "width" 1200) -}}
     {{ if $showThumb }}
       <img
         class="thumb height-20rem object-fit-cover"
-        src="{{ (.Page.Params.thumbnail | default .Site.Params.defaultThumbnailUrl) | absURL }}"
+        src="{{ $thumbnailURL }}"
         alt="{{ .Title }} thumbnail"
       />
     {{ end }}

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -6,9 +6,10 @@
     </header>
     <div class="author p-2 text-center">
       {{ with .thumbnailUrl }}
+        {{- $authorThumbURL := partial "image-url.html" (dict "site" $.Site "url" . "width" 256) -}}
         <img
           class="author-thumb mt-0 mx-auto mb-3 rounded-circle"
-          src="{{ . | absURL }}"
+          src="{{ $authorThumbURL }}"
           alt="{{ $authorAlt }}"
         />
       {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -128,7 +128,7 @@
   <script>
     window.addEventListener("load", function () {
       hljs.highlightAll();
-      hljs.initLineNumbersOnLoad(); //行番号用の起動コードを追加
+      hljs.initLineNumbersOnLoad(); // Initialize line numbers.
     });
   </script>
 {{ end }}

--- a/layouts/partials/image-url.html
+++ b/layouts/partials/image-url.html
@@ -1,0 +1,46 @@
+{{- $site := .site -}}
+{{- $rawURL := .url | default "" -}}
+{{- $width := .width | default 0 -}}
+{{- $keepRelative := .keepRelative | default false -}}
+{{- $useCloudinary := $site.Params.useCloudinary | default false -}}
+{{- $cloudName := $site.Params.cloudinaryCloudName | default "" -}}
+
+{{- $fallback := "" -}}
+{{- if $keepRelative -}}
+  {{- $fallback = $rawURL -}}
+{{- else -}}
+  {{- $fallback = $rawURL | absURL -}}
+{{- end -}}
+
+{{- if not $useCloudinary -}}
+  {{- $fallback -}}
+{{- else -}}
+  {{- if eq $cloudName "" -}}
+    {{- $fallback -}}
+  {{- else -}}
+    {{- $expectedPrefix := printf "https://res.cloudinary.com/%s/image/upload/" $cloudName -}}
+    {{- if not (strings.HasPrefix $rawURL $expectedPrefix) -}}
+      {{- $fallback -}}
+    {{- else -}}
+      {{- $segments := split $rawURL "/image/upload/" -}}
+      {{- if ne (len $segments) 2 -}}
+        {{- $fallback -}}
+      {{- else -}}
+        {{- $basePath := index $segments 0 -}}
+        {{- $publicPath := index $segments 1 -}}
+        {{- $head := index (split $publicPath "/") 0 -}}
+        {{- if and (strings.HasPrefix $head "v") (strings.Contains $head ",") -}}
+          {{- $fallback -}}
+        {{- else if not (strings.HasPrefix $publicPath "v") -}}
+          {{- $fallback -}}
+        {{- else -}}
+          {{- $transform := "f_auto,q_auto" -}}
+          {{- if gt $width 0 -}}
+            {{- $transform = printf "%s,w_%d" $transform $width -}}
+          {{- end -}}
+          {{- printf "%s/image/upload/%s/%s" $basePath $transform $publicPath -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -35,6 +35,8 @@
 {{ $title := "title" }}
 {{ $description := "description" }}
 {{ $shortDescription := "shortDescription" }}
+{{- $metaImage := .Params.thumbnail | default .Site.Params.defaultThumbnailUrl -}}
+{{- $metaImageURL := partial "image-url.html" (dict "site" .Site "url" $metaImage "width" 1200) -}}
 
 {{ if .IsPage }}
   {{ .Scratch.Set $title .Title }}
@@ -54,10 +56,7 @@
 <meta property="og:title" content="{{ .Scratch.Get $title }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:site_name" content="{{ .Site.Title }}" />
-<meta
-  property="og:image"
-  content="{{ absURL (.Params.thumbnail | default .Site.Params.defaultThumbnailUrl ) }}"
-/>
+<meta property="og:image" content="{{ $metaImageURL }}" />
 <meta
   property="og:type"
   content="
@@ -121,7 +120,4 @@
 {{ else }}
   <meta name="twitter:description" content="{{ .Scratch.Get $description }}" />
 {{ end }}
-<meta
-  name="twitter:image"
-  content="{{ absURL (.Params.thumbnail | default .Site.Params.defaultThumbnailUrl ) }}"
-/>
+<meta name="twitter:image" content="{{ $metaImageURL }}" />

--- a/layouts/partials/sidebar-toc.html
+++ b/layouts/partials/sidebar-toc.html
@@ -1,5 +1,5 @@
 {{ if .Params.toc }}
-  {{/* NOTE: md以下では表示しないようにする */}}
+  {{/* NOTE: Hidden below the lg breakpoint. */}}
   <div class="toc d-none d-lg-block text-decoration-none overflow-auto">
     {{ .TableOfContents }}
   </div>

--- a/layouts/shortcodes/cldimg.html
+++ b/layouts/shortcodes/cldimg.html
@@ -1,0 +1,98 @@
+{{- /* Required */ -}}
+{{- $url := .Get "url" -}}
+{{- if not $url -}}
+  {{- if or (.Get "publicID") (.Get "id") -}}
+    {{- errorf "cldimg shortcode: publicID/id is no longer supported. Use url with base Cloudinary URL (no transforms): https://res.cloudinary.com/<cloud>/image/upload/v..." -}}
+  {{- end -}}
+  {{- errorf "cldimg shortcode: url is required" -}}
+{{- end -}}
+
+{{- $alt := .Get "alt" | default "" -}}
+{{- if eq $alt "" -}}
+  {{- warnf "cldimg shortcode recommends alt: url=%s in page %s" $url .Page.Path -}}
+{{- end -}}
+
+{{- $class := .Get "class" | default "" -}}
+{{- $sizes := .Get "sizes" | default "(min-width: 1400px) 1320px, (min-width: 1200px) 1140px, (min-width: 992px) 960px, 100vw" -}}
+{{- $loading := .Get "loading" | default "lazy" -}}
+{{- $crop := .Get "crop" | default "" -}}
+{{- $caption := .Get "caption" | default "" -}}
+{{- $useCloudinary := site.Params.useCloudinary | default false -}}
+
+{{- if not $useCloudinary -}}
+  <figure>
+    <img
+      src="{{ $url }}"
+      alt="{{ $alt }}"
+      class="{{ $class }}"
+      loading="{{ $loading }}"
+      decoding="async"
+    />
+    {{- if $caption -}}
+      <figcaption>{{ $caption }}</figcaption>
+    {{- end -}}
+  </figure>
+{{- else -}}
+  {{- $cloudName := site.Params.cloudinaryCloudName -}}
+  {{- if not $cloudName -}}
+    {{- errorf "cldimg shortcode: site.Params.cloudinaryCloudName is required when useCloudinary=true" -}}
+  {{- end -}}
+
+  {{- $expectedPrefix := printf "https://res.cloudinary.com/%s/image/upload/" $cloudName -}}
+  {{- if not (strings.HasPrefix $url $expectedPrefix) -}}
+    {{- errorf "cldimg shortcode: url must start with %s. received=%s" $expectedPrefix $url -}}
+  {{- end -}}
+
+  {{- $segments := split $url "/image/upload/" -}}
+  {{- if ne (len $segments) 2 -}}
+    {{- errorf "cldimg shortcode: invalid Cloudinary URL format. expected /image/upload/v... received=%s" $url -}}
+  {{- end -}}
+  {{- $basePath := index $segments 0 -}}
+  {{- $publicPath := index $segments 1 -}}
+
+  {{- if not (strings.HasPrefix $publicPath "v") -}}
+    {{- errorf "cldimg shortcode: url must be non-transformed base URL in /image/upload/v... format. received=%s" $url -}}
+  {{- end -}}
+
+  {{- if not (strings.Contains $url "/image/upload/v") -}}
+    {{- errorf "cldimg shortcode: url must contain /image/upload/v... (no transformations before version). received=%s" $url -}}
+  {{- end -}}
+
+  {{- if strings.Contains $publicPath "/" -}}
+    {{- $head := index (split $publicPath "/") 0 -}}
+    {{- if and (strings.HasPrefix $head "v") (strings.Contains $head ",") -}}
+      {{- errorf "cldimg shortcode: url includes transformation options before version. remove options like f_auto,w_800 and pass base URL only. received=%s" $url -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $widths := slice 320 480 640 768 960 1200 1600 -}}
+  {{- $base := "f_auto,q_auto" -}}
+  {{- if $crop -}}
+    {{- $base = printf "%s,%s" $base $crop -}}
+  {{- end -}}
+
+  {{- $srcW := 768 -}}
+  {{- $src := printf "%s/image/upload/%s,w_%d/%s" $basePath $base $srcW $publicPath -}}
+
+  {{- $srcset := slice -}}
+  {{- range $widths -}}
+    {{- $u := printf "%s/image/upload/%s,w_%d/%s %dw" $basePath $base . $publicPath . -}}
+    {{- $srcset = $srcset | append $u -}}
+  {{- end -}}
+
+
+  <figure>
+    <img
+      src="{{ $src }}"
+      srcset="{{ delimit $srcset ", " }}"
+      sizes="{{ $sizes }}"
+      alt="{{ $alt }}"
+      class="{{ $class }}"
+      loading="{{ $loading }}"
+      decoding="async"
+    />
+    {{- if $caption -}}
+      <figcaption>{{ $caption }}</figcaption>
+    {{- end -}}
+  </figure>
+{{- end -}}

--- a/layouts/shortcodes/cldimg.html
+++ b/layouts/shortcodes/cldimg.html
@@ -22,7 +22,7 @@
 {{- if not $useCloudinary -}}
   <figure>
     <img
-      src="{{ $url }}"
+      src="{{ $url | absURL }}"
       alt="{{ $alt }}"
       class="{{ $class }}"
       loading="{{ $loading }}"

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -7,9 +7,14 @@
     {{- warnf "img shortcode requires alt (or caption fallback): src=%s in page %s" (.Get "src") .Page.Path -}}
   {{- end -}}
 {{- end -}}
+{{- $targetWidth := 0 -}}
+{{- with (.Get "w") -}}
+  {{- $targetWidth = int . -}}
+{{- end -}}
+{{- $imgSrcURL := partial "image-url.html" (dict "site" .Site "url" (.Get "src") "width" $targetWidth) -}}
 <figure {{ if .Get "class" }}class="{{ .Get "class" }}"{{ end }}>
   <img
-    src="{{ .Get "src" | absURL }}"
+    src="{{ $imgSrcURL }}"
     alt="{{ $alt }}"
     {{ with (.Get "w") }}width="{{ . }}"{{ end }}{{ with (.Get "h") }}
       height="{{ . }}"


### PR DESCRIPTION
## Overview

This PR adds default Cloudinary support with a global toggle and automatic URL transformation across content images and thumbnail/meta image paths.

This branch is derived from feat/enforce-alt-attributes to avoid conflicts and keep alt-related changes consistent.

## Changes

- Added params toggle `useCloudinary` and `cloudinaryCloudName` config keys.
- Added shared URL resolver partial to switch behavior globally:
  - `useCloudinary: false` -> keep normal image URLs.
  - `useCloudinary: true` -> transform eligible Cloudinary base URLs.
- Added new shortcode `cldimg` with URL validation and responsive `srcset` generation.
- Applied shared URL resolution to:
  - markdown render-image
  - list/home thumbnails
  - article thumbnails
  - OGP/Twitter images
  - author thumbnail
  - existing `img` shortcode source URL
- Added detailed Cloudinary guidance documents (EN/JA).
- Kept getting-started as quick-start and linked to detailed docs.

## Related Issues

- N/A

## Checklist

- [x] Self-review done (following `review.prompt.md`)
- [x] Hugo production build passes: `cd exampleSite && hugo --gc --minify`
- [x] Docs updated if behavior changed
- [x] No unrelated changes included
- [x] No unnecessary commented-out code included

## Notes for Reviewers

- Non-Cloudinary URLs remain unchanged even when `useCloudinary=true`.
- `cldimg` is strict for Cloudinary URL format when the feature toggle is enabled.
