### PR TITLE
fix: load highlight.js only on article pages

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -104,8 +104,8 @@
   {{ end }}
 {{ end }}
 
-{{/* syntax highlisht */}}
-{{ if .Site.Params.EnableHighlight | default true }}
+{{/* syntax highlight */}}
+{{ if and (.Site.Params.EnableHighlight | default true) .IsPage }}
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/base16/espresso.min.css"


### PR DESCRIPTION
## Overview

Load highlight.js assets only on article pages instead of all pages to reduce unnecessary asset loading.

## Changes

- Updated syntax-highlight loading condition in `layouts/partials/head.html`
- Changed condition from `EnableHighlight` only to `EnableHighlight && .IsPage`
- Fixed a minor typo in the nearby template comment (`highlisht` -> `highlight`)

## Related Issues

N/A

## Checklist

- [x] Self-review done (following `review.prompt.md`)
- [x] Hugo production build passes: `cd exampleSite && hugo --gc --minify`
- [ ] Docs updated if behavior changed
- [x] No unrelated changes included
- [x] No unnecessary commented-out code included

## Notes for Reviewers

- Scope is intentionally minimal (single template condition update).
- With this change, list/top/taxonomy pages no longer include highlight.js assets.
