### PR TITLE
chore(release): prepare v2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "HikaeMe",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@algolia/client-search": "^5.55.1",
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
     "test:e2e": "playwright test",
     "update": "ncu -u && npm install --ignore-scripts"
   },
-  "version": "2.0.2"
+  "version": "2.0.3"
 }


### PR DESCRIPTION
## Overview

Prepare release v2.0.3 by updating project version metadata on dev workflow branch.

## Changes

- Bumped version in package.json from 2.0.2 to 2.0.3
- Bumped version in package-lock.json from 2.0.2 to 2.0.3

## Related Issues

- N/A

## Checklist

- [x] Self-review done (following `review.prompt.md`)
- [x] Hugo production build passes: `cd exampleSite && hugo --gc --minify`
- [ ] Docs updated if behavior changed
- [x] No unrelated changes included
- [x] No unnecessary commented-out code included

## Notes for Reviewers

- Playwright browser dependencies were installed locally to run e2e tests.
- Sass deprecation warnings are pre-existing and not part of this release-prep change.
